### PR TITLE
add vscode devcontainer config for easy development setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8, 8.1, 8.0, 7, 7.4, 7.3, 8-bullseye, 8.1-bullseye, 8.0-bullseye, 7-bullseye, 7.4-bullseye, 7.3-bullseye, 8-buster, 8.1-buster, 8.0-buster, 7-buster, 7.4-buster
+ARG VARIANT=8-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/php:0-${VARIANT}
+
+# Install MariaDB client
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y mariadb-client \ 
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install php-mysql driver
+RUN docker-php-ext-install mysqli pdo pdo_mysql
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# copy the apache config and enable the site
+COPY vsmoddb.conf /etc/apache2/sites-available/
+RUN ln -s /etc/apache2/sites-available/vsmoddb.conf /etc/apache2/sites-enabled/vsmoddb.conf
+# enable apache rewrite module
+RUN a2enmod rewrite
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.2/containers/php-mariadb
+// Update the VARIANT arg in docker-compose.yml to pick a PHP version
+{
+	"name": "PHP & MySQL (Community)",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	
+	// Set *default* container specific settings.json values on container create.
+	"settings": { },
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"felixfbecker.php-debug",
+		"felixfbecker.php-intellisense",
+		"mrmlnc.vscode-apache"
+	],
+	// start the apache webserver
+	"postStartCommand": "apachectl start",
+
+	// For use with PHP or Apache (e.g.php -S localhost:8080 or apache2ctl start)
+	"forwardPorts": [8080, 3306],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+services: 
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Update 'VARIANT' to pick a version of PHP version: 8, 8.1, 8.0, 7, 7.4
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: "7.4"
+        # Optional Node.js version
+        NODE_VERSION: "lts/*"
+    volumes:
+      - ..:/workspace:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+    restart: unless-stopped
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: unless-stopped
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: moddb
+      MYSQL_USER: vsmoddb
+      MYSQL_PASSWORD: vsmoddb
+
+  # mysql-workbench:
+  #   image: lscr.io/linuxserver/mysql-workbench
+  #   environment:
+  #     - PUID=1000
+  #     - PGID=1000
+  #     - TZ=Europe/London
+  #   volumes:
+  #     - ../:/vsmoddb
+  #   ports:
+  #     - 4444:3000
+  #   cap_add:
+  #     - IPC_LOCK
+  #   restart: unless-stopped
+  
+volumes:
+  mysql-data:

--- a/.devcontainer/vsmoddb.conf
+++ b/.devcontainer/vsmoddb.conf
@@ -1,0 +1,36 @@
+ServerName stage.mods.vintagestory.at
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	ServerName stage.mods.vintagestory.at
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+	<Directory "/var/www/html/">
+	        AllowOverride All
+	</Directory>
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Simply click reopen in container and it should start building the devcontainer a
 Now edit the [config.php](lib/config.php) to match the settings in the [dockerdocker-compose.yml](.devcontainer/docker-compose.yml) for the db `MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD`
 and add `127.0.0.1	stage.mods.vintagestory.at`  to your hosts file on your local machine.
 
-To deploy the database to the mysql instance open the [model.mwb](db/model.mwb) in MySQL Workbench and `Database > Forward Engineer`.
-Finally fill the database with some default values by running [tables.sql](db/tables.sql) script.
+To deploy the database to the mysql instance run the [tables.sql](db/tables.sql) script against the database. You can use MySQL WOrkbench or any other mysql tool. When connecting from your local machine use localhost and 3306 (default) port to connect.
 
 There is also a optional MySQL Workbench container that when enabled in the [dockerdocker-compose.yml](.devcontainer/docker-compose.yml) can be reached at [http://localhost:4444/](http://localhost:4444/). To connect to the mysql database from workbench container use `db` for the hostname.
 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,22 @@ List all info for given mod. Modid can be either the numbered id as retrieved by
 Example: http://mods.vintagestory.at/api/mod/6<br>
 String example: http://mods.vintagestory.at/api/mod/carrycapacity
 
+
+# Development setup
+You can use the provided vscode devcontainer to get up an running without installing everything on your own.
+
+Requiered for that is docker installed aswell as docker-compose and vscode with the [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+Then you can open the [devcontainer.json](.devcontainer/devcontainer.json) in vscode and it should promt you 
+```
+Folder contains a Dev Container configuration file. Reopen folder to develop in a container ([learn more](https://aka.ms/vscode-remote/docker)).
+```
+Simply click reopen in container and it should start building the devcontainer and starting the mysql database aswell.
+
+Now edit the [config.php](lib/config.php) to match the settings in the [dockerdocker-compose.yml](.devcontainer/docker-compose.yml) for the db `MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD`
+and add `127.0.0.1	stage.mods.vintagestory.at`  to your hosts file on your local machine.
+
+To deploy the database to the mysql instance open the [model.mwb](db/model.mwb) in MySQL Workbench and `Database > Forward Engineer`.
+Finally fill the database with some default values by running [tables.sql](db/tables.sql) script.
+
+There is also a optional MySQL Workbench container that when enabled in the [dockerdocker-compose.yml](.devcontainer/docker-compose.yml) can be reached at [http://localhost:4444/](http://localhost:4444/). To connect to the mysql database from workbench container use `db` for the hostname.
+


### PR DESCRIPTION
This PR adds a vscode devcontainer to ease dev environment setup.
I also added some simple instructions to get up and running with everything.

Used in this setup is:
Docker and docker-compose
PHP 7.4
MySQL Server 8
there is also a optional mysql workbench container that can be enabled