### PR TITLE
Fix api/mods not returning null for no logo

### DIFF
--- a/api.php
+++ b/api.php
@@ -120,7 +120,7 @@ function listMod($modid) {
 		"name" => $row['name'],
 		"text" => $row['text'],
 		"author" => $row['author'],
-		"logofilename" => "asset/{$row['assetid']}/" . $row['logofilename'],
+		"logofilename" => $row['logofilename'] ? "asset/{$row['assetid']}/" . $row['logofilename'] : null,
 		"homepageurl" => $row['homepageurl'],
 		"sourcecodeurl" => $row['sourcecodeurl'],
 		"trailervideourl" => $row['trailervideourl'],


### PR DESCRIPTION
API returns mod with "logo": "files/asset/<assetId>/" instead of null if there is no logo

https://mods.vintagestory.at/api/mods?text=SpearFix - no logo, but "logo":"files\/asset\/3357\/"
https://mods.vintagestory.at/api/mods?text=tpnet - has logo and "logo":"files\/asset\/10\/logo.jpg"