### PR TITLE
Return int in releases too

### DIFF
--- a/api.php
+++ b/api.php
@@ -105,7 +105,7 @@ function listMod($modid) {
 		$releases[] = array(
 			"mainfile" => "asset/{$file['assetid']}/" . $file["filename"],
 			"filename" => $file["filename"],
-			"fileid" => intval($file['fileid']),
+			"fileid" => $file['fileid'] ? intval($file['fileid']) : null,
 			"downloads" => intval($file["downloads"]),
 			"tags" => $tags,
 			"modidstr" => $release['modidstr'],

--- a/api.php
+++ b/api.php
@@ -105,8 +105,8 @@ function listMod($modid) {
 		$releases[] = array(
 			"mainfile" => "asset/{$file['assetid']}/" . $file["filename"],
 			"filename" => $file["filename"],
-			"fileid" => $file['fileid'],
-			"downloads" => $file["downloads"],
+			"fileid" => intval($file['fileid']),
+			"downloads" => intval($file["downloads"]),
 			"tags" => $tags,
 			"modidstr" => $release['modidstr'],
 			"modversion" => $release['modversion'],


### PR DESCRIPTION
`downloads` and `fileid` are int, but unlike other fields are returned as string