### PR TITLE
Add releaseid for release response

### DIFF
--- a/api.php
+++ b/api.php
@@ -103,6 +103,7 @@ function listMod($modid) {
 		$file = $con->getRow("select * from file where assetid=? limit 1", array($release['assetid']));
 		
 		$releases[] = array(
+			"releaseid" => $release['releaseid'],
 			"mainfile" => "asset/{$file['assetid']}/" . $file["filename"],
 			"filename" => $file["filename"],
 			"fileid" => $file['fileid'],


### PR DESCRIPTION
Required if you want to restore database data locally. Because modidstr+modversion or fileid is hard to use as a unique key. For example, [here](https://mods.vintagestory.at/api/mod/emotemenu) there is only modversion and fileid, and [here](https://mods.vintagestory.at/api/mod/HangingOilLamps) only modidstr+modversion