### PR TITLE
Toastyderek/mod updates api

### DIFF
--- a/api.php
+++ b/api.php
@@ -128,7 +128,7 @@ switch ($action) {
 			$modWithVersions[$modid] = $modVersion;
 		}
 
-		listModNewestVersion($modWithVersions);
+		listOutOfDateMods($modWithVersions);
 		break;
 }
 
@@ -387,7 +387,7 @@ function resolveTags($tagscached)
 	return $tags;
 }
 
-function listModNewestVersion($modsWithVersions)
+function listOutOfDateMods($modsWithVersions)
 {
 	$outOfDateMods = array();
 	foreach($modsWithVersions as $modid => $version) {
@@ -396,7 +396,7 @@ function listModNewestVersion($modsWithVersions)
 			$outOfDateMods[$modid] = $latestRelease;
 		}
 	}
-	good(array("statuscode" => 200, "updates" => empty($outOfDateMods) ? null : $outOfDateMods));
+	good(array("statuscode" => 200, "updates" => $outOfDateMods));
 }
 
 function getLatestRelease($modid) {

--- a/api.php
+++ b/api.php
@@ -120,7 +120,11 @@ switch ($action) {
 		$modsQueryStrings = explode(',', $_GET["mods"]);
 		$modWithVersions = array();
 		foreach($modsQueryStrings as $modWithVersion) {
-			[$modid, $modVersion] = explode('@', $modWithVersion);
+			$modVersionInfo = explode('@', $modWithVersion);
+			if (count($modVersionInfo) != 2) {
+				fail("400");
+			}
+			[$modid, $modVersion] = $modVersionInfo;
 			$modWithVersions[$modid] = $modVersion;
 		}
 


### PR DESCRIPTION
This PR create an API endpoint called `updates` which takes a list of mods and their corresponding versions (presumably, from a script that fetches the user's local mod list) and lists any mods that can be updated and information about the release for each mod.

The API call spec is:
`GET api/updates/?mods=mod1@mod1version,mod2@mod2version,...,modN@modNversion`

Returns `{"statuscode":"400"}` if the request is malformed.

The successful API response spec is:
```json
{
    "statuscode": "200",
    "updates": {
        "mod1": {
            "releaseid": mod1releaseid,
            "mainfile": "files\/asset\/1\/{{filename}}.zip",
            "filename": "filename.zip",
            "fileid": mod1fileid,
            "downloads": 0,
            "tags": ["tag1", "tag2", "..."],
            "modidstr": "mod1idstr",
            "modversion": "latestModVersionStr",
            "created": "2023-07-06 21:55:56"
        }
    }
}
```