### PR TITLE
removed deprecated mysql option

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,6 @@ services:
 
   db:
     image: mysql
-    command: --default-authentication-plugin=mysql_native_password
     restart: unless-stopped
     volumes:
       - mysql-data:/var/lib/mysql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,6 @@ services:
 
   db:
     image: mysql
-    command: --default-authentication-plugin=mysql_native_password
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
removes `--default-authentication-plugin=mysql_native_password`.

This PR resolves #29. 

I did not observe anything not working, but i also don't know what other software would interact with the mod portal on its server. 