### PR TITLE
fixed wrong table name join in /mod/ api

### DIFF
--- a/api.php
+++ b/api.php
@@ -167,7 +167,7 @@ function listMod($modid)
 			`mod` 
 			join asset on (`mod`.assetid = asset.assetid)
 			join user on (`asset`.createdbyuserid = user.userid)
-			left join file as logofile on (`mod`.logofileid = file.fileid)
+			left join file as logofile on (`mod`.logofileid = logofile.fileid)
 		where
 			asset.statusid=2
 			and modid=?


### PR DESCRIPTION
The (bunny)cdn integration introduced a malformed sql statement in one of the api endpoints, namely the `/mod/<id>` endpoint. This pr fixes said issue. I've checked again and have not found this exact copy paste error anywhere else. 