### PR TITLE
Expose `lastreleased` in the `/mod/<id>` api endpoint

### DIFF
--- a/api.php
+++ b/api.php
@@ -251,7 +251,10 @@ function listMod($modid)
 		"type"            => $row['type'],
 		"created"         => $row['created'],
 		"lastreleased"    => $row['lastreleased'],
-		"lastmodified"    => $row['lastmodified'], //NOTE(Rennorb): Updated on download number changes, basically pointless. Should we change this behaviour?
+		//NOTE(Rennorb): This field updates on download number changes and is therefore pretty much useless.
+		// Removing it is however not a good idea becasue it's a public api, and changing it to work differently also isn't great because it would make the behaviour inconsistent between different tables.
+		// We therefore simply keep it in this jank state for now, until a potential future breaking version.
+		"lastmodified"    => $row['lastmodified'],
 		"tags"            => resolveTags($row['tagscached']),
 		"releases"        => $releases,
 		"screenshots"     => $screenshots

--- a/api.php
+++ b/api.php
@@ -250,7 +250,8 @@ function listMod($modid)
 		"side"            => $row['side'],
 		"type"            => $row['type'],
 		"created"         => $row['created'],
-		"lastmodified"    => $row['lastmodified'],
+		"lastreleased"    => $row['lastreleased'],
+		"lastmodified"    => $row['lastmodified'], //NOTE(Rennorb): Updated on download number changes, basically pointless. Should we change this behaviour?
 		"tags"            => resolveTags($row['tagscached']),
 		"releases"        => $releases,
 		"screenshots"     => $screenshots


### PR DESCRIPTION
closes #35, ref #34, #20

This also brings up discussion around `lastmodified`, which gets updated on database level. This isn't really desirable imo, as this also triggers on download number updates, but apparently does _not_ update on release removal (#20). This is likely behavior we want to change, as in its current state the field is effectively worthless.

There is an argument to be made as to not change any public behavior, but i would just change in this specific case. I will however wait for your input before i do so, unless i happen to be extra motivated tomorrow, in which case you will get another pr before then. 