### PR TITLE
Add conditional download tracking links for files depending on their extension

### DIFF
--- a/lib/asseteditor.php
+++ b/lib/asseteditor.php
@@ -108,7 +108,7 @@ class AssetEditor extends AssetController {
 		foreach ($files as &$file) {
 			$file["created"] = date("M jS Y, H:i:s", strtotime($file["created"]));
 			$file["ext"] = substr($file["filename"], strrpos($file["filename"], ".")+1); // no clue why pathinfo doesnt work here
-			$file["url"] = formatCdnUrl($file);
+			$file["url"] = maybeFormatDownloadTrackingUrlDependingOnFileExt($file);
 		}
 		unset($file);
 		

--- a/lib/cdn/bunny.php
+++ b/lib/cdn/bunny.php
@@ -160,7 +160,7 @@ function formatCdnUrlFromCdnPath($cdnpath, $filenamepostfix = '') {
  * Formats a download link to the file.
  * This url is meant to enforce that the enduser gets prompted to download the file, as compared to a "normal" link which might just display the file in browser.
  * 
- * @param array{cdnpath: string, filename:string, fileid:int} $file
+ * @param array{cdnpath: string, filename:string} $file
  * @return string
  */
 function formatCdnDownloadUrl($file) {

--- a/lib/core.php
+++ b/lib/core.php
@@ -590,12 +590,32 @@ else {
 
 /**
  * Formats a download tracking link to the file.
- * This url is meant to enforce that the enduser gets prompted to download the file, as compared to a "normal" link which might just display the file in browser.
+ * This url is meant to enforce that the enduser gets prompted to download the file, as compared to a "normal" link which might just display the file in browser as well as tracking that download (-attempt).
  * 
  * @param array{filename:string, fileid:int} $file
  * @return string
  */
-function formatDownloadUrl($file)
+function formatDownloadTrackingUrl($file)
 {
 	return "/download/{$file['fileid']}/{$file['filename']}";
+}
+
+/**
+ * Formats a download tracking link to the file if the extension is not one of the image types we support.
+ * In that case this url is meant to enforce that the enduser gets prompted to download the file, as compared to a "normal" link which might just display the file in browser as well as tracking that download (-attempt).
+ * Otherwise this just returns the cdn download url without tracking.
+ * This is meant specifically for the purpose of the asset file attachement; open images in browser, download everything else and track the download.
+ * 
+ * @param array{filename:string, fileid:int, ext:string, cdnpath:string} $file
+ * @return string
+ */
+function maybeFormatDownloadTrackingUrlDependingOnFileExt($file)
+{
+	switch($file['ext']) {
+		case 'png': case 'jpg': case 'gif':
+			return formatCdnDownloadUrl($file);
+
+		default:
+			return formatDownloadTrackingUrl($file);
+	}
 }

--- a/show-release.php
+++ b/show-release.php
@@ -34,7 +34,7 @@ if ($assetid) {
 	foreach ($files as &$file) {
 		$file["created"] = date("M jS Y, H:i:s", strtotime($file["created"]));
 		$file["ext"] = substr($file["filename"], strrpos($file["filename"], ".")+1); // no clue why pathinfo doesnt work here
-		$file["url"] = formatCdnUrl($file);
+		$file["url"] = formatDownloadTrackingUrl($file);
 	}
 	unset($file);
 	$view->assign("files", $files);

--- a/templates/edit-asset-files.tpl
+++ b/templates/edit-asset-files.tpl
@@ -17,7 +17,7 @@
 						</a>
 					{/if}
 					<a href="" class="delete" data-fileid="{$file['fileid']}"></a>
-					<a href="{formatDownloadUrl($file)}" class="download">&#11123;</a>
+					<a href="{formatDownloadTrackingUrl($file)}" class="download">&#11123;</a>
 				</div>
 			{/foreach}
 			

--- a/templates/edit-task.tpl
+++ b/templates/edit-task.tpl
@@ -102,7 +102,7 @@
 						</a>
 					{/if}
 					<a href="" class="delete" data-fileid="{$file['fileid']}"></a>
-					<a href="{formatDownloadUrl($file)}" class="download">&#11123;</a>
+					<a href="{formatDownloadTrackingUrl($file)}" class="download">&#11123;</a>
 				</div>
 			{/foreach}
 		</div>

--- a/templates/show-mod.tpl
+++ b/templates/show-mod.tpl
@@ -107,7 +107,7 @@
 						{if count($releases[0]['tags']) > 0}<span class="text-weak">Latest file for {$releases[0]['tags'][count($releases[0]['tags'])-1]['name']}:</span><br>
 						{else}<span class="text-weak">Latest version:</span><br>{/if}
 
-						<a class="downloadbutton" href="{formatDownloadUrl($releases[0]['file'])}">{$releases[0]['file']['filename']}</a>
+						<a class="downloadbutton" href="{formatDownloadTrackingUrl($releases[0]['file'])}">{$releases[0]['file']['filename']}</a>
 						{if !empty($releases[0]['modidstr'])}<a style="padding-left:10px;" href="vintagestorymodinstall://{$releases[0]['modidstr']}@{$releases[0]['modversion']}"><abbr title="Works only on Windows and v1.18.0-rc.1 or newer">1-click install</abbr></a>{/if}
 					</p>
 				{/if}
@@ -168,7 +168,7 @@
 							<td>{if !empty($release['file'])}{intval($release['file']['downloads'])}{/if}</td>
 							<td>{fancyDate($release['created'])}</td>
 							<td><a href="#showchangelog">Show</a></td>
-							<td>{if !empty($release['file'])}<a class="downloadbutton" href="{formatDownloadUrl($release['file'])}">{$release['file']['filename']}</a>{/if}</td>
+							<td>{if !empty($release['file'])}<a class="downloadbutton" href="{formatDownloadTrackingUrl($release['file'])}">{$release['file']['filename']}</a>{/if}</td>
 							<td>{if !empty($release['modidstr'])}<a href="vintagestorymodinstall://{$release['modidstr']}@{$release['modversion']}">Install now</a>{/if}</td>
 						</tr>
 						{assign var="first" value="1"}


### PR DESCRIPTION
This tries to do download tracking for non-image files, including setting the correct filename.

This is about the rectangular "file" box of asset attachments, not the download button on that object.