### PR TITLE
Hide deleted comments in additional places

### DIFF
--- a/home.php
+++ b/home.php
@@ -116,6 +116,7 @@ $latestcomments = $con->getAll("
 		join assettype on (asset.assettypeid = assettype.assettypeid)
 	where 
 		asset.statusid=2
+		and comment.deleted = 0
 		and comment.created > date_sub(now(), interval 14 day)
 	order by
 		comment.created desc

--- a/lib/asseteditor.php
+++ b/lib/asseteditor.php
@@ -122,7 +122,7 @@ class AssetEditor extends AssetController {
 			from 
 				comment 
 				join user on (comment.userid = user.userid)
-			where assetid=?
+			where assetid=? and comment.deleted = 0
 			order by comment.created desc
 		", array($this->assetid));
 		

--- a/show-release.php
+++ b/show-release.php
@@ -46,7 +46,7 @@ if ($assetid) {
 		from 
 			comment 
 			join user on (comment.userid = user.userid)
-		where assetid=?
+		where assetid=? and comment.deleted = 0
 		order by comment.created desc
 	", array($assetid));
 	


### PR DESCRIPTION
Apparently i forgot to hide deleted comments in some places, namely _the homepage_ ... This hides them on the homepage, the release viewer, and the generic asset editor.

In the future we might want to show them again for moderators, but for now its better to just hide them unconditionally imo.