### PR TITLE
fixed release- and deleted comment notification

### DIFF
--- a/delete-comment.php
+++ b/delete-comment.php
@@ -44,6 +44,10 @@ if (!empty($_POST["delete"])) {
 		$changelog = array("Deleted comment (".$cmt["text"].") of user " . $user['userid'] . "\nComment text was:\n" . $cmt["text"]);
 		logAssetChanges($changelog, $cmt['assetid']);
 	}
+
+	// Mark notifications for this comment as read so they get hidden for the notified user.
+	//NOTE(Rennorb): We could also delete them completely, but i opted to just "read" them.
+	$con->Execute("update notification set `read` = 1 where `type` in ('mentioncomment', 'newcomment') and recordid = ?", array($commentid));
 	
 	exit(json_encode(array("ok" => 1)));
 }

--- a/lib/assetimpl/releaseeditor.php
+++ b/lib/assetimpl/releaseeditor.php
@@ -89,13 +89,15 @@ class ReleaseEditor extends AssetEditor {
 		$con->Execute("delete from asset where assetid=?", array($this->assetid));
 		$con->Execute("delete from `{$this->tablename}` where {$this->tablename}id=?", array($this->recordid));
 
-		//TODO(Rennorb) @correctness: We cannot remove notifications for deleted releases here like we do with comment notifications, because those notifications are tracked by modid, not by releaseid.
-		// Because of this we cannot trivially remove those notifications, because if we just go by modid we could run into the following scenario:
-		// 1. new release 1 -> notification (unread)
-		// 2. new release 2 -> notification (unread)
-		// 3. delete release 2 -> we delete both notifications even though only one should be removed
-		// I think it is possible to do work out something with the creation dates for releases and notifications, but for now we just let these "invalid" notifications exist, as to not potentially remove valid ones.
-		// Another option would be to change the tracking asset for those notifications, and track the actual release instead of the mod. That would be a larger change, and this right now is just a small fix so I'm not doing it right now.
+		//TODO(Rennorb) @correctness: Remove / hide unread release notifications for deleted releases.
+		// We cannot remove notifications for deleted releases trivially like we do with comment notifications because release notifications are tracked by modid, not by releaseid.
+		// Since we only have the modid in the notification entry we could run into the following scenario:
+		// 1. new release 1 for mod 1 -> notification 1 (unread)
+		// 2. new release 2 for mod 1 -> notification 2 (unread)
+		// 3. delete release 2 -> we would delete both notifications even though only one should be removed, because both of them are tracked by the same modid
+		// I think it is possible to figure out a solution to this using the creation dates for releases and notifications, or change the notifications to be tracking releaseid instead of modid.
+		// Both of those would however be a larger change, and right now I'm just supplying a small fix for notifications.
+		// For now we just let these "invalid" notifications exist, as to not potentially remove valid ones which would be a lot worse.
 
 		if (!empty($mod)) {
 			updateGameVersionsCached($mod['modid']);

--- a/lib/assetimpl/releaseeditor.php
+++ b/lib/assetimpl/releaseeditor.php
@@ -89,6 +89,14 @@ class ReleaseEditor extends AssetEditor {
 		$con->Execute("delete from asset where assetid=?", array($this->assetid));
 		$con->Execute("delete from `{$this->tablename}` where {$this->tablename}id=?", array($this->recordid));
 
+		//TODO(Rennorb) @correctness: We cannot remove notifications for deleted releases here like we do with comment notifications, because those notifications are tracked by modid, not by releaseid.
+		// Because of this we cannot trivially remove those notifications, because if we just go by modid we could run into the following scenario:
+		// 1. new release 1 -> notification (unread)
+		// 2. new release 2 -> notification (unread)
+		// 3. delete release 2 -> we delete both notifications even though only one should be removed
+		// I think it is possible to do work out something with the creation dates for releases and notifications, but for now we just let these "invalid" notifications exist, as to not potentially remove valid ones.
+		// Another option would be to change the tracking asset for those notifications, and track the actual release instead of the mod. That would be a larger change, and this right now is just a small fix so I'm not doing it right now.
+
 		if (!empty($mod)) {
 			updateGameVersionsCached($mod['modid']);
 		

--- a/notification.php
+++ b/notification.php
@@ -31,7 +31,7 @@ if ($not['type'] == "newrelease") {
 		where modid=?
 	", array($not['recordid']));
 
-	$url = $row['modalias'] ? "/" . $row['modalias'] : "show/mod/" . $row['assetid'];
+	$url = $row['modalias'] ? "/" . $row['modalias'] : "/show/mod/" . $row['assetid'];
 	header("Location: {$url}#tab-files");
 } else {
 
@@ -45,7 +45,7 @@ if ($not['type'] == "newrelease") {
 		where commentid=?
 	", array($not['recordid']));
 
-	$url = $cmt['modalias'] ? "/" . $cmt['modalias'] : "show/mod/" . $cmt['assetid'];
+	$url = $cmt['modalias'] ? "/" . $cmt['modalias'] : "/show/mod/" . $cmt['assetid'];
 	header("Location: {$url}#cmt-{$cmt['commentid']}");
 }
 


### PR DESCRIPTION
This fixes the redirect links for release notifications targeting mods without custom url, as well as removing notifications where the corresponding target comment has been deleted.

I didn't do this for deleted releases yet, because that change would be quite a bit more complex. See the comment in releaseeditor.php for a longer explanation.

I hope it is ok to leave this TODO in there, i don't know how to express the information otherwise. 

[tracking]
https://discord.com/channels/302152934249070593/810541931469078568/1342697535470305310  
https://discord.com/channels/302152934249070593/810541931469078568/1343032671307169863  