### PR TITLE
Fix aspect ratio issue with logo images

### DIFF
--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -14,7 +14,7 @@
 
 	<link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
 
-	<link href="/web/css/style.css?version=34" rel="stylesheet" type="text/css">
+	<link href="/web/css/style.css?version=35" rel="stylesheet" type="text/css">
 	<link href="/web/css/chosen.min.css" rel="stylesheet" type="text/css">
 	<link href="/web/css/dialog.css" rel="stylesheet" type="text/css">
 	<link href="/web/css/jquery.fancybox.min.css" rel="stylesheet" type="text/css">

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -48,6 +48,10 @@ a:hover {
 	color: white;
 }
 
+.flex-spacer {
+	flex-grow: 1;
+}
+
 
 .logo img {
 	width: 280px; 
@@ -238,10 +242,12 @@ ul.submenu a {
 }
 
 .mods {
-	clear:both;
-	display: flex;
-	/*justify-content: center;*/
-	flex-wrap: wrap;
+	clear: both;
+	display: grid;
+	justify-content: space-evenly;
+	grid-template-columns: repeat(auto-fill, 300px);
+	grid-template-rows: auto;
+	gap: 1em;
 }
 
 .mods div.mod {
@@ -249,16 +255,11 @@ ul.submenu a {
 	flex-shrink: 1; /* Fix for mobile devices */
 	overflow: hidden;
 	
-	flex-grow: 1;
 	background-color: rgba(255, 255, 255, 0.6);
 	width: 300px;
-	max-width: 375px;
 	height: 300px;
-	margin-right: 10px;
-	margin-bottom: 10px;
-	margin-top: 10px;
 	border-radius: .25rem;
-	border: 1px solid #rgba(255,255,255,0.8);
+	border: 1px solid rgba(255,255,255,0.8);
 	box-shadow: 1px 1px 4px #999;
 }
 
@@ -281,8 +282,6 @@ ul.submenu a {
 }
 
 .mod.draft {
-	width: 300px;
-	height: 298px !important;
 	border: 1.5px dashed gray !important; 
 	position: relative;
 }
@@ -1390,7 +1389,7 @@ span.username {
     background-image: linear-gradient(to bottom,#08c,#0077b3);
     background-repeat: repeat-x;
     outline: 0;
-    filter: progid:DXImageTransform.Microsof;
+    filter: progid:DXImageTransform.Microsoft;
 }
 
 


### PR DESCRIPTION
This change allows to maintain roughly the old look while not resizing the individual mod containers. Resizing them is "problematic", because that cuts of the logo images when the mod nodes get stretched. This cannot be avoided because stretching the nodes changes the aspect ratio and therefore images wont fit, no matter how you resize them. Other modes using side-bars for the images also look very bad. 

It is absolutely debatable weather it is preferable to keep cutting of images, or to apply this slight change to the resizing behavior.

Comparison between new and old:
Old:   
![image](https://github.com/user-attachments/assets/34f331a9-8d4a-47ec-b189-010a9e498696)
(see tracking link for even worse version of this)

New:  
![image](https://github.com/user-attachments/assets/0bf57bd8-7d17-4913-b8d1-740fd4445064)



This also fixes some random other broken styles that are either invalid css or misalignment issues.

[tracking]
https://discord.com/channels/302152934249070593/810541931469078568/1343333479064145990