### PR TITLE
Fixes filedrop filename encoding issue.

### DIFF
--- a/download.php
+++ b/download.php
@@ -3,15 +3,16 @@
 // expects to be called as  download/132465[/somefile.png]
 // but the game client downloads it using ?fileid=1231 so we need to remain backwards compatible
 
-$fileid = $_GET["fileid"];
-
-if (count($urlparts) > 2) {
-	$fileid = intval($urlparts[1]);
+$fileid = intval($_GET["fileid"] ?? $urlparts[1] ?? 0);
+if($fileid === 0) {
+	http_response_code(400);
+	exit("Missing fileid.");
 }
+
 $file = $con->getRow("select * from file where fileid=?", array($fileid));
 if (!$file) {
 	http_response_code(404);
-	exit("file not found");
+	exit("File not found.");
 }
 
 // do download tracking

--- a/lib/cdn/none.php
+++ b/lib/cdn/none.php
@@ -117,7 +117,7 @@ function formatCdnDownloadUrl($file) {
 {
 	$path_parts = explode('/', substr(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), 1), 2);
 	if($path_parts[0] === 'cdndl') {
-		$filepath = $config["basepath"] . "files/" . $path_parts[1]; // easy path traversal, we don't care. :NoneCDN_NoSecurity
+		$filepath = $config["basepath"] . "files/" . urldecode($path_parts[1]); // easy path traversal, we don't care. :NoneCDN_NoSecurity
 		
 		// copy paste from the old dl code
 		header('Content-Description: File Transfer');
@@ -133,7 +133,7 @@ function formatCdnDownloadUrl($file) {
 		exit();
 	}
 	else if($path_parts[0] === 'cdnfile') {
-		$filepath = $config["basepath"] . "files/" . $path_parts[1]; // easy path traversal, we don't care. :NoneCDN_NoSecurity
+		$filepath = $config["basepath"] . "files/" . urldecode($path_parts[1]); // easy path traversal, we don't care. :NoneCDN_NoSecurity
 
 		$type = mime_content_type($filepath);
 		header('Content-Type: '.$type);

--- a/templates/footer.tpl
+++ b/templates/footer.tpl
@@ -18,7 +18,7 @@
 	<script type="text/javascript" src="/web/js/wysiwyg.js?version=25"></script>
 	<script type="text/javascript" src="/web/js/tinymce/tinymce.min.js"></script>
 
-	<script type="text/javascript" src="/web/js/jquery.filedrop.js"></script>
+	<script type="text/javascript" src="/web/js/jquery.filedrop.js?v=2"></script>
 	<script type="text/javascript" src="/web/js/datepicker.min.js"></script>
 	<script type="text/javascript" src="/web/js/i18n/datepicker.en.js"></script>
 	

--- a/web/js/jquery.filedrop.js
+++ b/web/js/jquery.filedrop.js
@@ -144,7 +144,7 @@
       builder += boundary;
       builder += crlf;
       builder += 'Content-Disposition: form-data; name="' + (paramname||"") + '"';
-      builder += '; filename="' + encodeURIComponent(filename) + '"';
+      builder += '; filename="' + String.fromCharCode(...(new TextEncoder('windows-1252')).encode(filename)) + '"';
       builder += crlf;
 
       builder += 'Content-Type: ' + mime;


### PR DESCRIPTION
This modifies the jquery-filedrop code, as it did not adhere to the specification with their implementation, which caused a mismatch on how uploaded files are encoded between their version and a native file upload.

This also fixes some issues with the download system, and the `none` cdn that either were never checked, or introduced by previous fixes.

[tracking]
https://discord.com/channels/302152934249070593/810541931469078568/1344819090862375024