### PR TITLE
Fix team user links on mod pages

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -8,7 +8,6 @@ $cnt = 0;
 // check `DEBUGUSER` first, $sessiontoken could be set by mods.vintagestory.at even if we're browsing stage.mods.vintagestory.at
 if (DEBUGUSER === 1) {
 	$userid = empty($_GET['showas']) ? 1 : (intval($_GET['showas']) ?: 1); // append ?showas=<id> to view the page as a different user
-	 $userid = 5;
 	$user = $con->getRow("
 		select user.*, role.code as rolecode, rec.reason as bannedreason
 		from user 

--- a/show-mod.php
+++ b/show-mod.php
@@ -38,7 +38,8 @@ if ($assetid) {
 	$teammembers = $con->getAll("
 		select 
 			user.userid, 
-			user.name 
+			user.name,
+			user.created as joindate
 		from 
 			teammembers 
 			join user on teammembers.userid = user.userid 
@@ -49,7 +50,7 @@ if ($assetid) {
 
 	if ($teammembers) {
 		foreach ($teammembers as $idx => $teammember) {
-			$teammembers[$idx]['usertoken'] = getUserHash($teammember['userid'], $asset['createduserjoindate']);
+			$teammembers[$idx]['usertoken'] = getUserHash($teammember['userid'], $teammember['joindate']);
 		}
 
 		$view->assign("teammembers", $teammembers);
@@ -166,8 +167,10 @@ $view->assign("asset", $asset);
 
 $view->assign("isfollowing", empty($user) ? 0 : $con->getOne("select modid from `follow` where modid=? and userid=?", array($asset['modid'], $user['userid'])));
 
-processTeamInvitations($asset, $user);
-processOwnershipTransfers($asset, $user);
+if (!empty($user)) {
+	processTeamInvitations($asset, $user);
+	processOwnershipTransfers($asset, $user);
+}
 
 $view->display("show-mod");
 


### PR DESCRIPTION
This fixes the user link generation for team members on the mod page, as it was using the wrong creation date. 

Also getting rid of some warnings and removing the dev user id overwrite.

[tracking]
https://discord.com/channels/302152934249070593/810541931469078568/1344985997183553576