### PR TITLE
Add mod contributions to 'by user' mod lists

### DIFF
--- a/home.php
+++ b/home.php
@@ -12,12 +12,13 @@ if (!empty($user)) {
 			join `mod` on asset.assetid = `mod`.assetid
 			left join status on asset.statusid = status.statusid
 			left join file as logofile on `mod`.logofileid = logofile.fileid
+			left join teammembers on `mod`.modid = teammembers.modid and teammembers.accepted = 1
 		where
-			asset.createdbyuserid = ?
+			(asset.createdbyuserid = ? or teammembers.userid = ?)
 		order by asset.created desc
 	";
 	
-	$ownmods = $con->getAll($sql, array($user['userid']));
+	$ownmods = $con->getAll($sql, array($user['userid'], $user['userid']));
 	
 	foreach($ownmods as &$row) {
 		unset($row['text']);

--- a/show-user.php
+++ b/show-user.php
@@ -26,13 +26,14 @@ $sql = "
 				join `mod` on asset.assetid = `mod`.assetid
 				left join status on asset.statusid = status.statusid
 				left join file as logofile on mod.logofileid = logofile.fileid
+				left join teammembers on `mod`.modid = teammembers.modid and teammembers.accepted = 1
 			where
-				asset.createdbyuserid = ?
+				(asset.createdbyuserid = ? or teammembers.userid = ?)
 				and asset.statusid = 2
 			order by asset.created desc
 		";
 
-$authormods = $con->getAll($sql, array($shownuser['userid']));
+$authormods = $con->getAll($sql, array($shownuser['userid'], $shownuser['userid']));
 
 foreach ($authormods as &$row) {
 	unset($row['text']);

--- a/templates/home.tpl
+++ b/templates/home.tpl
@@ -14,7 +14,7 @@ Cheers,<br>
 </p>
 {else}
 	{if !empty($mods)}
-		<h3>Your uploaded mods</h3>
+		<h3>Your mod contributions</h3>
 		<div class="mods">
 			{foreach from=$mods item=mod}
 				{include file="list-mod-entry"}

--- a/templates/show-user.tpl
+++ b/templates/show-user.tpl
@@ -31,7 +31,7 @@
 
 {if !empty($mods)}
 
-	<h3>Mod created by {$shownuser['name']}</h3>
+	<h3>Mods {$shownuser['name']} contributed to</h3>
 
 	<div class="mods">
 		{foreach from=$mods item=mod}


### PR DESCRIPTION
This change adds the mods a user is on the team of to their user page, as well as their home page.

This also changes the heading above those sections from "[your mods]" to "[Mods you've contributed to]" to make it clear that the user did not necessarily create these mods on their own.

Splitting up these lists into "created" and "contributed to" would be an option, but for now I went with a simple solution.

[tracking]
https://discord.com/channels/302152934249070593/810541931469078568/1344985840606122016