### PR TITLE
Improved search by adding ascore metric

### DIFF
--- a/lib/search-mods.php
+++ b/lib/search-mods.php
@@ -183,7 +183,7 @@ function queryModSearch($searchParams)
 				// To realize those, we combine the LOCATE expression with a bit of bit twiddling to archive an ordering of
 				// not found = 0 < found < found at the start.
 
-				// POSITION returns 0 for not found, 1 based index of the match otherwise.
+				// LOCATE returns 0 for not found, 1 based index of the match otherwise.
 
 				// The key insight here is that clamping to two, subtracting one and masking off the least two bits of the resulting -1, 0 and 1
 				// produces 0b11, 0b00, 0b01 which is exactly the inverse of the order we are looking for (0b11 > 0b01 > 0b00).

--- a/lib/search-mods.php
+++ b/lib/search-mods.php
@@ -161,7 +161,7 @@ function queryModSearch($searchParams)
 
 	$joinClauses = '';
 	$whereClauses = '';
-	$matchScoreSelect = '';
+	$matchScoreSelect = '0 as matchScore,';
 	$sqlParams = [];
 
 	$orderBy = VALID_ORDER_BY_COLUMNS[$searchParams['order'][0]][0].' '.$searchParams['order'][1];


### PR DESCRIPTION
This works and does the job, but it OBLITERATES lookup performance because we cannot use indices anymore, getting rid of the whole point of the cursor approach.   
The database goes back to doing a complete table scan for each block to return, because the score metric is not part of the indices.  
We also cannot force it to use one anyway, because of the sorting by score. This causes it to again, do a complete table scan with filesort.

IT does however drastically improve the search results, so maybe its still worth it? IT should still be better than before, where we were always returning all results, and we were doing the sort in php.