### PR TITLE
Improve mod search, fix server tweaks search token

### DIFF
--- a/templates/list-mod.tpl
+++ b/templates/list-mod.tpl
@@ -62,6 +62,8 @@
 				<option value="o"{if $selectedParams['category'] === 'o'} selected="selected"{/if}>Other</option>
 			</select>
 		</span>
+		{else}
+		<input type="hidden" name="c" value="s">
 		{/if}
 
 		<span data-label="Mod Type">


### PR DESCRIPTION
- Word tokenization allows finding mods regardless of word order ("story vintage" now finds "Vintage Story")
- Added urlAlias and modIdentifier to searchable fields (users can search by mod ID like "carrycapacity")
- Filter out words shorter than 2 characters to reduce noise
- Limit to 5 words max for performance
- Use CONCAT_WS to reduce SQL parameters (1 LIKE per word instead of 5)
- Add trailing spaces to JOIN clauses to prevent SQL syntax errors when filters combine
- Server tweaks tab now preserves category filter when searching