### PR TITLE
Fixing DevContainer Build Fail

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
-FROM mcr.microsoft.com/devcontainers/php:1-8.2-bullseye
+FROM mcr.microsoft.com/devcontainers/php:2-8.4-bullseye
+
+# Remove unneeded repositories
+RUN rm /etc/apt/sources.list.d/yarn.list
 
 # Install MariaDB client
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
- Updates the devcontainer build version (newest is `2.0.2`, see: https://github.com/devcontainers/images/blob/main/src/php/history/2.0.2.md#variant-84-apache-bullseye) and aligns PHP version with what is used in `docker/Dockerfile`.
- The `yarn` repository throws a GPG error because apparently the published image by Microsoft is broken - however, I don't see `yarn` being used, so I simply removed the repository

```diff
0.316 Get:1 http://deb.debian.org/debian bullseye InRelease [75.1 kB]
[2026-02-17T19:57:51.999Z] 0.347 Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]
[2026-02-17T19:57:51.999Z] 
[2026-02-17T19:57:51.999Z] 0.363 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]
0.380 Get:4 https://dl.yarnpkg.com/debian stable InRelease
0.437 Get:5 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
+ 0.547 Err:4 https://dl.yarnpkg.com/debian stable InRelease
+ 0.547   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
0.680 Get:6 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [449 kB]
[2026-02-17T19:57:51.999Z] 0.689 Get:7 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
1.200 Reading package lists...
1.413 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
1.413 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

The setup still works, the database is correctly set up and running and after updating the `hosts` file I can access the page.

<img width="1919" height="988" alt="grafik" src="https://github.com/user-attachments/assets/bd41c183-5bed-4181-96e9-b3337ffb8b4e" />
