### PR TITLE
Fix download re-count never triggering after 24h

### DIFF
--- a/download.php
+++ b/download.php
@@ -26,7 +26,7 @@ if(!DB_READONLY) {
 	if (!$lastDownload) {
 		$countAsSeparateDownload = true;
 		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
-	} else if (strtotime($lastDownload) - time() > 24*3600) {
+	} else if (time() - strtotime($lastDownload) > 24*3600) {
 		$countAsSeparateDownload = true;
 		//TODO(Rennorb) @correctness: This does not produce the correct result for trending points.
 		$con->execute('UPDATE fileDownloadTracking SET lastDownload = NOW() WHERE fileId = ? and ipAddress = ?', $identifier);

--- a/lib/cdn/bunny.php
+++ b/lib/cdn/bunny.php
@@ -220,7 +220,7 @@ function bunny_pullLogsAndUpdateDownloadNumbers($date)
 		if (!$lastDownload) {
 			$countAsSeparateDownload = true;
 			$con->Execute('INSERT INTO fileDownloadTracking (lastUpdate, fileId, ipAddress) VALUES (?, ?, ?)', [$date, $fileId, $remoteip]);
-		} else if (strtotime($lastDownload) - $time > 24*3600) {
+		} else if ($time - strtotime($lastDownload) > 24*3600) {
 			$countAsSeparateDownload = true;
 			$con->Execute('UPDATE fileDownloadTracking SET lastDownload = ? WHERE fileId = ? and ipAddress = ?', [$date, $fileId, $remoteip]);
 		}


### PR DESCRIPTION
The 24-hour re-count check in download tracking computes `strtotime($lastDownload) - time()`, which is always negative (past minus present), so the `> 24*3600` condition never passes. After the first download from a given IP, all later downloads of the same file are silently ignored no matter how much time goes by.

Swapped the operands so elapsed time is calculated correctly.

Same issue in both `download.php` and `lib/cdn/bunny.php`.

See https://www.php.net/manual/en/function.time.php
See https://www.php.net/manual/en/function.strtotime.php