### PR TITLE
Skip totalModCount query on API requests

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,6 +40,8 @@ if($urlparts[0] === 'api') { // :ReservedUrlPrefixes
 
 include("lib/csp.php");
 
+$view->assign('totalModCount', $con->getOne('SELECT COUNT(*) from mods'), null, true);
+
 //TODO(Rennorb) @cleanup @perf: Move view initialization here, after api branch.
 $view->assign('headerHighlight', null, null, true);
 if(DB_READONLY) addMessage(MSG_CLASS_OK.' permanent', 'We are currently in readonly mode. All editing is disabled, but you can still browse and download.');

--- a/lib/core.php
+++ b/lib/core.php
@@ -45,7 +45,7 @@ $view->assign("assetserver", $config['assetserver']);
 
 
 //NOTE(Rennorb): Technically we should only count the public mods, but in reality this probably doesn't matter for production and just counting all mods makes the query simpler.
-$view->assign('totalModCount', $con->getOne('SELECT COUNT(*) from mods'), null, true);
+// Moved to index.php after the API branch -- API requests don't render the header where this is used.
 
 
 


### PR DESCRIPTION
The `SELECT COUNT(*) FROM mods` in `core.php` runs on every request, including API calls that never render the header template where the value is displayed.

Moved it to `index.php` after the API branch, so it only runs on pages that actually need it.

This also addresses the existing TODO on index.php:
```
//TODO(Rennorb) @cleanup @perf: Move view initialization here, after api branch.
```

See https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_count