### PR TITLE
Avoid fetching full mod descriptions on home page

### DIFF
--- a/home.php
+++ b/home.php
@@ -3,7 +3,7 @@
 if (!empty($user)) {
 	$ownMods = $con->getAll("
 		SELECT
-			a.*,
+			a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
 			m.*,
 			logo.cdnPath AS logoCdnPath,
 			logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
@@ -21,7 +21,6 @@ if (!empty($user)) {
 	", [$user['userId'], $user['userId']]);
 
 	foreach($ownMods as &$mod) {
-		unset($mod['text']);
 		$mod['tags'] = [];
 		$mod['from'] = $user['name'];
 		$mod['dbPath'] = formatModPath($mod);
@@ -34,7 +33,7 @@ if (!empty($user)) {
 	//TODO(Rennorb) @cleanup
 	$followedMods = $con->getAll("
 		SELECT
-			a.*,
+			a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
 			m.*,
 			logo.cdnPath AS logoCdnPath,
 			logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
@@ -69,7 +68,7 @@ if (!empty($user)) {
 
 $latestMods = $con->getAll("
 	SELECT
-		a.*,
+		a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
 		m.*,
 		logo.cdnPath AS logoCdnPath,
 		logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,


### PR DESCRIPTION
The three queries in `home.php` used `SELECT a.*` which pulls the full HTML description (`TEXT` column, up to 64KB per mod) from the `assets` table. None of the home page templates use this field — `ownMods` even had an `unset($mod['text'])` right after the query to throw it away.

Replaced `a.*` with the specific columns the templates actually need.

For a user with 20 mods and 50 followed mods, this avoids transferring potentially hundreds of KB of unused HTML from the database on every home page load.

See https://dev.mysql.com/doc/refman/8.0/en/blob.html (TEXT storage)
See https://www.percona.com/blog/dont-use-select-star/