### PR TITLE
Enable JPEG support in GD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,10 @@ ENV GID=${GID}
 
 # Install php-mysql driver & gd to handle screenshots
 RUN apt update \
-    && apt install -y zlib1g-dev libpng-dev \
+    && apt install -y zlib1g-dev libpng-dev libjpeg62-turbo-dev \
     && rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-install mysqli pdo pdo_mysql gd
+RUN docker-php-ext-configure gd --with-jpeg \
+    && docker-php-ext-install mysqli pdo pdo_mysql gd
 
 RUN usermod -u ${UID} www-data \
     && groupmod -g ${GID} www-data

--- a/lib/img.php
+++ b/lib/img.php
@@ -104,7 +104,7 @@ function copyImageResized($file, $width = 0, $height = 0, $proportional = true, 
 		$image = imagecreatefromgif($file);
 	  break;
 	  case IMAGETYPE_JPEG:
-		$image = imagecreatefromjpeg($file); //TODO(Rennorb) @bug: undefined function. php version? missing lib?
+		$image = imagecreatefromjpeg($file);
 	  break;
 	  case IMAGETYPE_PNG:
 		$image = imagecreatefrompng($file);


### PR DESCRIPTION
GD was compiled without `--with-jpeg`, so `imagecreatefromjpeg()` was undefined and JPEG uploads would fatal error.

Added `libjpeg62-turbo-dev` and `docker-php-ext-configure gd --with-jpeg` to the Dockerfile, matching the pattern from the [official PHP Docker image docs](https://hub.docker.com/_/php).

See https://www.php.net/manual/en/image.installation.php