### PR TITLE
Use prepared statement for POINT() insert in fileupload

### DIFF
--- a/lib/core.php
+++ b/lib/core.php
@@ -284,11 +284,6 @@ function createADOConnection($config, $persistent = true)
 	$con->execute("SET CHARACTER SET utf8mb4");
 	$con->execute("SET NAMES utf8mb4");
 
-	//TODO(Rennorb) @correctness: This is supposed to allow usage of POINT(x, y) in inserts, but those still fail with
-	// "Cannot get geometry object from data you send to the GEOMETRY field"
-	// :BrokenSqlPointType
-	//$con->setCustomMetaType('P', MYSQLI_TYPE_GEOMETRY, 'POINT');
-
 	return $con;
 }
 

--- a/lib/fileupload.php
+++ b/lib/fileupload.php
@@ -129,8 +129,7 @@ function processFileUpload($file, $assetTypeId, $parentAssetId, $parentModId) {
 	$con->execute("INSERT INTO files (`$foldedKeys`) VALUES ($placeholders)", array_values($data));
 	$fileId = $con->Insert_ID();
 	if($acceptedImage) {
-		// :BrokenSqlPointType
-		$con->execute("INSERT INTO fileImageData (fileId, hasThumbnail, size) VALUES ($fileId, 1, POINT($width, $height))");
+		$con->execute("INSERT INTO fileImageData (fileId, hasThumbnail, size) VALUES (?, 1, POINT(?, ?))", [$fileId, $width, $height]);
 	}
 
 	if($parentAssetId) logAssetChanges(array("Uploaded file '{$file['name']}'"), $parentAssetId);


### PR DESCRIPTION
`fileupload.php` was interpolating `$fileId`, `$width`, `$height` directly into SQL as a workaround for a POINT() binding issue. `POINT(?, ?)` with bound parameters already works in `edit-mod.php:617`, so the workaround is unnecessary.

Removed the commented-out `setCustomMetaType` call and its TODO in `createADOConnection`.