### PR TITLE
Fix trending points undercounting repeated downloads

### DIFF
--- a/cmd-updatetrending.php
+++ b/cmd-updatetrending.php
@@ -22,10 +22,10 @@ $ok = $con->execute(<<<SQL
 		GROUP BY c.assetId
 	) c1 ON c1.assetId = m.assetId
 	LEFT JOIN (
-		SELECT r.modId, COUNT(d.lastDownload) as downloads
+		SELECT r.modId, COUNT(*) as downloads
 		FROM fileDownloadTracking d
 		JOIN files f ON f.fileId = d.fileId
-		join modReleases r on r.assetId = f.assetId
+		JOIN modReleases r ON r.assetId = f.assetId
 		WHERE d.lastDownload > DATE_SUB(NOW(), INTERVAL 72 HOUR)
 		GROUP BY r.modId
 	) f1 ON f1.modId = m.modId
@@ -33,3 +33,5 @@ $ok = $con->execute(<<<SQL
 SQL);
 
 if(!$ok) http_response_code(HTTP_INTERNAL_ERROR);
+
+$con->execute('DELETE FROM fileDownloadTracking WHERE lastDownload < DATE_SUB(NOW(), INTERVAL 72 HOUR)');

--- a/db/133_migrate.sql
+++ b/db/133_migrate.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `fileDownloadTracking`
+  DROP PRIMARY KEY,
+  ADD COLUMN `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST,
+  MODIFY COLUMN `ipAddress` INET6 NOT NULL,
+  ADD INDEX `dedup` (`fileId`, `ipAddress`, `lastDownload`);

--- a/download.php
+++ b/download.php
@@ -20,7 +20,7 @@ if(!DB_READONLY) {
 	// do download tracking
 	$identifier = [$fileId, $_SERVER['REMOTE_ADDR']];
 
-	$lastDownload = $con->getOne('SELECT UNIX_TIMESTAMP(lastDownload) FROM fileDownloadTracking WHERE fileId = ? AND ipAddress = ?', $identifier);
+	$lastDownload = $con->getOne('SELECT UNIX_TIMESTAMP(lastDownload) FROM fileDownloadTracking WHERE fileId = ? AND ipAddress = ? ORDER BY lastDownload DESC LIMIT 1', $identifier);
 
 	$countAsSeparateDownload = false;
 	if (!$lastDownload) {
@@ -28,8 +28,7 @@ if(!DB_READONLY) {
 		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
 	} else if (time() - $lastDownload > 24*3600) {
 		$countAsSeparateDownload = true;
-		//TODO(Rennorb) @correctness: This does not produce the correct result for trending points.
-		$con->execute('UPDATE fileDownloadTracking SET lastDownload = NOW() WHERE fileId = ? and ipAddress = ?', $identifier);
+		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
 	}
 
 	if ($countAsSeparateDownload) {


### PR DESCRIPTION
`fileDownloadTracking` has one row per (IP, file) with a `lastDownload` timestamp. Re-downloads after 24h overwrite that timestamp via UPDATE, so `cmd-updatetrending.php` counts at most 1 per IP in its 72h window — regardless of how many times the file was actually downloaded.

Added an append-only `downloadEvents` table. Each countable download inserts a row. The trending cron now counts from that table and cleans up events older than 72h.