### PR TITLE
Fix mod description disappearing on Safari back/forward navigation

### DIFF
--- a/templates/show-mod.tpl
+++ b/templates/show-mod.tpl
@@ -322,6 +322,9 @@
 				});
 			});
 		});
+		window.addEventListener('pageshow', function(e) {
+			if (e.persisted) document.getElementById(location.hash === '#tab-files' ? 'tab-files' : 'tab-description').checked = true;
+		});
 	</script>
 	<script nonce="{$cspNonce}" type="text/javascript" src="/web/js/jquery.fancybox.min.js" async></script>
 	<link nonce="{$cspNonce}" href="https://cdnjs.cloudflare.com/ajax/libs/fotorama/4.6.4/fotorama.css" rel="stylesheet">


### PR DESCRIPTION
Safari's bfcache restores the DOM but doesn't re-execute inline scripts. The tab radio inputs revert to unchecked, hiding both tab contents until the user clicks another tab and back.

Added a `pageshow` event listener that re-checks the correct tab when the page is restored from bfcache (`event.persisted === true`).

Closes #80

See https://developer.mozilla.org/en-US/docs/Web/API/Window/pageshow_event
See https://web.dev/articles/bfcache