### PR TITLE
Add separate Mod ID search filter

### DIFF
--- a/cmd-updatetrending.php
+++ b/cmd-updatetrending.php
@@ -22,10 +22,10 @@ $ok = $con->execute(<<<SQL
 		GROUP BY c.assetId
 	) c1 ON c1.assetId = m.assetId
 	LEFT JOIN (
-		SELECT r.modId, COUNT(d.lastDownload) as downloads
+		SELECT r.modId, COUNT(*) as downloads
 		FROM fileDownloadTracking d
 		JOIN files f ON f.fileId = d.fileId
-		join modReleases r on r.assetId = f.assetId
+		JOIN modReleases r ON r.assetId = f.assetId
 		WHERE d.lastDownload > DATE_SUB(NOW(), INTERVAL 72 HOUR)
 		GROUP BY r.modId
 	) f1 ON f1.modId = m.modId

--- a/db/000_tables.sql
+++ b/db/000_tables.sql
@@ -295,12 +295,10 @@ ENGINE = InnoDB;
 
 
 CREATE TABLE IF NOT EXISTS `fileDownloadTracking` (
-  `ipAddress`    VARCHAR(255) NOT NULL,
+  `ipAddress`    INET6        NOT NULL,
   `fileId`       INT          NOT NULL,
   `lastDownload` DATETIME     NOT NULL DEFAULT NOW(),
-  PRIMARY KEY (`ipAddress`, `fileId`),
-  INDEX `ipaddress` (`ipAddress`),
-  INDEX `fileid` (`fileId`),
+  INDEX `identifier` (`fileId`, `ipAddress`, `lastDownload`),
   INDEX `lastDownload` (`lastDownload`)
 )
 ENGINE = InnoDB;

--- a/db/133_migrate.sql
+++ b/db/133_migrate.sql
@@ -1,0 +1,27 @@
+USE `moddb`;
+
+DELIMITER $$
+
+CREATE OR REPLACE PROCEDURE upgrade_database__moderation()
+BEGIN
+
+IF NOT EXISTS( (SELECT * FROM information_schema.STATISTICS WHERE TABLE_SCHEMA='moddb' AND
+ TABLE_NAME='fileDownloadTracking' AND COLUMN_NAME='ipAddress' and INDEX_NAME='identifier') ) THEN
+
+ALTER TABLE `fileDownloadTracking`
+  DROP PRIMARY KEY,
+  DROP INDEX `ipaddress`,
+  DROP INDEX `fileid`,
+  MODIFY COLUMN `ipAddress` INET6 NOT NULL,
+  ADD INDEX `identifier` (`fileId`, `ipAddress`, `lastDownload`);
+
+END IF;
+
+
+END $$
+
+CALL upgrade_database__moderation() $$
+
+DELIMITER ;
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,10 @@ ENV GID=${GID}
 
 # Install php-mysql driver & gd to handle screenshots
 RUN apt update \
-    && apt install -y zlib1g-dev libpng-dev \
+    && apt install -y zlib1g-dev libpng-dev libjpeg62-turbo-dev \
     && rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-install mysqli pdo pdo_mysql gd
+RUN docker-php-ext-configure gd --with-jpeg \
+    && docker-php-ext-install mysqli pdo pdo_mysql gd
 
 RUN usermod -u ${UID} www-data \
     && groupmod -g ${GID} www-data

--- a/download.php
+++ b/download.php
@@ -26,7 +26,7 @@ if(!DB_READONLY) {
 	if (!$lastDownload) {
 		$countAsSeparateDownload = true;
 		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
-	} else if (strtotime($lastDownload) - time() > 24*3600) {
+	} else if (time() - strtotime($lastDownload) > 24*3600) {
 		$countAsSeparateDownload = true;
 		//TODO(Rennorb) @correctness: This does not produce the correct result for trending points.
 		$con->execute('UPDATE fileDownloadTracking SET lastDownload = NOW() WHERE fileId = ? and ipAddress = ?', $identifier);

--- a/download.php
+++ b/download.php
@@ -20,21 +20,16 @@ if(!DB_READONLY) {
 	// do download tracking
 	$identifier = [$fileId, $_SERVER['REMOTE_ADDR']];
 
-	$lastDownload = $con->getOne('SELECT UNIX_TIMESTAMP(lastDownload) FROM fileDownloadTracking WHERE fileId = ? AND ipAddress = ?', $identifier);
+	$lastDownload = $con->getOne('SELECT UNIX_TIMESTAMP(lastDownload) FROM fileDownloadTracking WHERE (fileId, ipAddress) = (?, ?) ORDER BY lastDownload DESC LIMIT 1', $identifier);
+	if (!$lastDownload || (time() - $lastDownload) > DOWNLOAD_DEDUPLICATION_TIMESPAN) {
+		$con->startTrans();
 
-	$countAsSeparateDownload = false;
-	if (!$lastDownload) {
-		$countAsSeparateDownload = true;
 		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
-	} else if (time() - $lastDownload > 24*3600) {
-		$countAsSeparateDownload = true;
-		//TODO(Rennorb) @correctness: This does not produce the correct result for trending points.
-		$con->execute('UPDATE fileDownloadTracking SET lastDownload = NOW() WHERE fileId = ? and ipAddress = ?', $identifier);
-	}
 
-	if ($countAsSeparateDownload) {
 		$con->execute('UPDATE files SET downloads = downloads + 1 WHERE fileId = ?', [$fileId]);
 		$con->execute('UPDATE mods  SET downloads = downloads + 1 WHERE modId = (SELECT r.modId FROM modReleases r WHERE r.assetId = ?)', [$file['assetId']]);
+
+		$con->completeTrans();
 	}
 }
 

--- a/download.php
+++ b/download.php
@@ -20,13 +20,13 @@ if(!DB_READONLY) {
 	// do download tracking
 	$identifier = [$fileId, $_SERVER['REMOTE_ADDR']];
 
-	$lastDownload = $con->getOne('SELECT lastDownload FROM fileDownloadTracking WHERE fileId = ? AND ipAddress = ?', $identifier);
+	$lastDownload = $con->getOne('SELECT UNIX_TIMESTAMP(lastDownload) FROM fileDownloadTracking WHERE fileId = ? AND ipAddress = ?', $identifier);
 
 	$countAsSeparateDownload = false;
 	if (!$lastDownload) {
 		$countAsSeparateDownload = true;
 		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
-	} else if (time() - strtotime($lastDownload) > 24*3600) {
+	} else if (time() - $lastDownload > 24*3600) {
 		$countAsSeparateDownload = true;
 		//TODO(Rennorb) @correctness: This does not produce the correct result for trending points.
 		$con->execute('UPDATE fileDownloadTracking SET lastDownload = NOW() WHERE fileId = ? and ipAddress = ?', $identifier);

--- a/home.php
+++ b/home.php
@@ -3,7 +3,7 @@
 if (!empty($user)) {
 	$ownMods = $con->getAll("
 		SELECT
-			a.*,
+			a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
 			m.*,
 			logo.cdnPath AS logoCdnPath,
 			logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
@@ -21,7 +21,6 @@ if (!empty($user)) {
 	", [$user['userId'], $user['userId']]);
 
 	foreach($ownMods as &$mod) {
-		unset($mod['text']);
 		$mod['tags'] = [];
 		$mod['from'] = $user['name'];
 		$mod['dbPath'] = formatModPath($mod);
@@ -34,7 +33,7 @@ if (!empty($user)) {
 	//TODO(Rennorb) @cleanup
 	$followedMods = $con->getAll("
 		SELECT
-			a.*,
+			a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
 			m.*,
 			logo.cdnPath AS logoCdnPath,
 			logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
@@ -69,7 +68,7 @@ if (!empty($user)) {
 
 $latestMods = $con->getAll("
 	SELECT
-		a.*,
+		a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
 		m.*,
 		logo.cdnPath AS logoCdnPath,
 		logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,

--- a/index.php
+++ b/index.php
@@ -40,8 +40,14 @@ if($urlparts[0] === 'api') { // :ReservedUrlPrefixes
 
 include("lib/csp.php");
 
+
 //TODO(Rennorb) @cleanup @perf: Move view initialization here, after api branch.
+
+//NOTE(Rennorb): Technically we should only count the public mods, but in reality this probably doesn't matter for production and just counting all mods makes the query simpler.
+$view->assign('totalModCount', $con->getOne('SELECT COUNT(*) from mods'), null, true);
 $view->assign('headerHighlight', null, null, true);
+$view->assign("assetserver", $config['assetserver']);
+
 if(DB_READONLY) addMessage(MSG_CLASS_OK.' permanent', 'We are currently in readonly mode. All editing is disabled, but you can still browse and download.');
 
 

--- a/lib/cdn/bunny.php
+++ b/lib/cdn/bunny.php
@@ -220,7 +220,7 @@ function bunny_pullLogsAndUpdateDownloadNumbers($date)
 		if (!$lastDownload) {
 			$countAsSeparateDownload = true;
 			$con->Execute('INSERT INTO fileDownloadTracking (lastUpdate, fileId, ipAddress) VALUES (?, ?, ?)', [$date, $fileId, $remoteip]);
-		} else if (strtotime($lastDownload) - $time > 24*3600) {
+		} else if ($time - strtotime($lastDownload) > 24*3600) {
 			$countAsSeparateDownload = true;
 			$con->Execute('UPDATE fileDownloadTracking SET lastDownload = ? WHERE fileId = ? and ipAddress = ?', [$date, $fileId, $remoteip]);
 		}

--- a/lib/cdn/bunny.php
+++ b/lib/cdn/bunny.php
@@ -214,13 +214,13 @@ function bunny_pullLogsAndUpdateDownloadNumbers($date)
 		if (!$file) exit('file not found');
 		$fileId = $file['fileId'];
 
-		$lastDownload = $con->getOne('SELECT lastDownload FROM fileDownloadTracking WHERE fileId = ? and ipAddress = ?', [$fileId, $remoteip]);
+		$lastDownload = $con->getOne('SELECT UNIX_TIMESTAMP(lastDownload) FROM fileDownloadTracking WHERE fileId = ? and ipAddress = ?', [$fileId, $remoteip]);
 
 		$countAsSeparateDownload = false;
 		if (!$lastDownload) {
 			$countAsSeparateDownload = true;
 			$con->Execute('INSERT INTO fileDownloadTracking (lastUpdate, fileId, ipAddress) VALUES (?, ?, ?)', [$date, $fileId, $remoteip]);
-		} else if ($time - strtotime($lastDownload) > 24*3600) {
+		} else if ($time - $lastDownload > 24*3600) {
 			$countAsSeparateDownload = true;
 			$con->Execute('UPDATE fileDownloadTracking SET lastDownload = ? WHERE fileId = ? and ipAddress = ?', [$date, $fileId, $remoteip]);
 		}

--- a/lib/config.php
+++ b/lib/config.php
@@ -3,6 +3,15 @@ global $config;
 
 $config["authserver"] = "auth.vintagestory.at";
 
+/**
+ * @param string $name
+ * @param mixed $default
+ */
+function _define_default($name, $default)
+{
+	if(!defined($name)) define($name, $default);
+}
+
 // For local development purposes create lib/config.dev.php and put your config in there. That file is automatically ignored by version control.
 // Have a look at lib/cdn/bunny.php for relevant CDN config options.
 
@@ -22,11 +31,13 @@ if (strstr($_SERVER["SERVER_NAME"], "mods.vintagestory.stage")) {
 	}
 	$config['noncesalt'] = 'xzy';
 
-	if (!defined("DEBUG")) define("DEBUG", 1);
-	if (!defined("DEBUGUSER")) define("DEBUGUSER", 1);
+	_define_default("DEBUG", 1);
+	_define_default("DEBUGUSER", 1);
 
-	if (!defined("MOD_SEARCH_INITIAL_RESULTS")) define("MOD_SEARCH_INITIAL_RESULTS", 10);
-	if (!defined("MOD_SEARCH_PAGE_SIZE")) define("MOD_SEARCH_PAGE_SIZE", 10);
+	_define_default("MOD_SEARCH_INITIAL_RESULTS", 10);
+	_define_default("MOD_SEARCH_PAGE_SIZE", 10);
+
+	_define_default("DOWNLOAD_DEDUPLICATION_TIMESPAN", 60); // seconds
 } else {
 	$config["database"] = "moddb";
 	define("CDN", "bunny");
@@ -37,16 +48,18 @@ if (strstr($_SERVER["SERVER_NAME"], "mods.vintagestory.stage")) {
 		include($filepath);
 	}
 
-	if (!defined("DEBUG")) define("DEBUG", 0);
+	_define_default("DEBUG", 0);
 	define("DEBUGUSER", 0);
 
-	if (!defined("MOD_SEARCH_INITIAL_RESULTS")) define("MOD_SEARCH_INITIAL_RESULTS", 200);
-	if (!defined("MOD_SEARCH_PAGE_SIZE")) define("MOD_SEARCH_PAGE_SIZE", 200);
+	_define_default("MOD_SEARCH_INITIAL_RESULTS", 200);
+	_define_default("MOD_SEARCH_PAGE_SIZE", 200);
+
+	_define_default("DOWNLOAD_DEDUPLICATION_TIMESPAN", 24*3600); // seconds
 }
 
-if(!defined("DB_READONLY")) define("DB_READONLY", false);
+_define_default("DB_READONLY", false);
 
-if(!defined("DISABLE_USER_TAGS")) define('DISABLE_USER_TAGS', true);
+_define_default('DISABLE_USER_TAGS', true);
 define("TAG_MODAUTHOR_VOTES", 1); // Not yet fully implemented, keep this at one.
-if(!defined("TAG_DOWNVOTED_THRESHOLD")) define("TAG_DOWNVOTED_THRESHOLD", 0);
-if(!defined("TAG_HIDE_THRESHOLD")) define("TAG_HIDE_THRESHOLD", -20);
+_define_default("TAG_DOWNVOTED_THRESHOLD", 0);
+_define_default("TAG_HIDE_THRESHOLD", -20);

--- a/lib/core.php
+++ b/lib/core.php
@@ -41,15 +41,6 @@ function formatByteSize($size)
 }
 
 
-$view->assign("assetserver", $config['assetserver']);
-
-
-//NOTE(Rennorb): Technically we should only count the public mods, but in reality this probably doesn't matter for production and just counting all mods makes the query simpler.
-$view->assign('totalModCount', $con->getOne('SELECT COUNT(*) from mods'), null, true);
-
-
-
-
 function dump($var)
 {
 	echo "<pre style='background: #fff; color: #000; padding: .5em; border: solid 1px currentcolor;'>";

--- a/lib/core.php
+++ b/lib/core.php
@@ -284,11 +284,6 @@ function createADOConnection($config, $persistent = true)
 	$con->execute("SET CHARACTER SET utf8mb4");
 	$con->execute("SET NAMES utf8mb4");
 
-	//TODO(Rennorb) @correctness: This is supposed to allow usage of POINT(x, y) in inserts, but those still fail with
-	// "Cannot get geometry object from data you send to the GEOMETRY field"
-	// :BrokenSqlPointType
-	//$con->setCustomMetaType('P', MYSQLI_TYPE_GEOMETRY, 'POINT');
-
 	return $con;
 }
 

--- a/lib/fileupload.php
+++ b/lib/fileupload.php
@@ -129,8 +129,7 @@ function processFileUpload($file, $assetTypeId, $parentAssetId, $parentModId) {
 	$con->execute("INSERT INTO files (`$foldedKeys`) VALUES ($placeholders)", array_values($data));
 	$fileId = $con->Insert_ID();
 	if($acceptedImage) {
-		// :BrokenSqlPointType
-		$con->execute("INSERT INTO fileImageData (fileId, hasThumbnail, size) VALUES ($fileId, 1, POINT($width, $height))");
+		$con->execute("INSERT INTO fileImageData (fileId, hasThumbnail, size) VALUES (?, 1, POINT(?, ?))", [$fileId, $width, $height]);
 	}
 
 	if($parentAssetId) logAssetChanges(array("Uploaded file '{$file['name']}'"), $parentAssetId);

--- a/lib/img.php
+++ b/lib/img.php
@@ -104,7 +104,7 @@ function copyImageResized($file, $width = 0, $height = 0, $proportional = true, 
 		$image = imagecreatefromgif($file);
 	  break;
 	  case IMAGETYPE_JPEG:
-		$image = imagecreatefromjpeg($file); //TODO(Rennorb) @bug: undefined function. php version? missing lib?
+		$image = imagecreatefromjpeg($file);
 	  break;
 	  case IMAGETYPE_PNG:
 		$image = imagecreatefrompng($file);

--- a/lib/search-mods.php
+++ b/lib/search-mods.php
@@ -74,6 +74,10 @@ function validateModSearchInputs(&$outParams, $trimText)
 		$outParams['filters']['tags'] = $tags;
 	}
 
+	if(!empty($_REQUEST['modid'])) {
+		$outParams['filters']['modid'] = trim($_REQUEST['modid']);
+	}
+
 	if(!empty($_REQUEST['a'])) {
 		$contributorHash = filter_var($_REQUEST['a'], FILTER_UNSAFE_RAW | FILTER_FLAG_STRIP_LOW);
 		if($contributorHash !== $_REQUEST['a']) {
@@ -247,6 +251,15 @@ function queryModSearch($searchParams)
 
 				$orderBy = 'matchScore DESC, '.$orderBy;
 
+				break;
+
+			case 'modid':
+				$joinClauses .= 'JOIN modReleases mr ON mr.modId = m.modId AND mr.identifier = ? LEFT JOIN modReleaseRetractions mrr ON mrr.releaseId = mr.releaseId ';
+				array_splice($sqlParams, $joinParamsOffset, 0, $value);
+				$joinParamsOffset++;
+
+				$whereClauses .= $whereClauses ? ' AND ' : 'WHERE ';
+				$whereClauses .= 'mrr.reason IS NULL';
 				break;
 
 			case 'tags':

--- a/lib/user.php
+++ b/lib/user.php
@@ -172,117 +172,147 @@ function loadNotifications($loadAll)
 	$limit = $loadAll ? '' : 'LIMIT 10';
 	$notifications = $con->getAll("SELECT * FROM notifications WHERE userId = ? AND !`read` ORDER BY created DESC $limit", [$user['userId']]);
 
+	if(empty($notifications)) {
+		$view->assign('notifications', []);
+		return;
+	}
+
+	$modIds = [];
+	$commentIds = [];
+	$warningIds = [];
+	$userIds = [];
+	$releaseAssetIds = [];
+
+	foreach($notifications as $notification) {
+		$recordId = $notification['recordId'];
+		switch($notification['kind']) {
+			case NOTIFICATION_NEW_RELEASE:
+			case NOTIFICATION_MOD_LOCKED:
+			case NOTIFICATION_MOD_UNLOCK_REQUEST:
+			case NOTIFICATION_MOD_UNLOCKED:
+			case NOTIFICATION_MOD_OWNERSHIP_TRANSFER_REQUEST:
+				$modIds[$recordId] = true;
+				break;
+			case NOTIFICATION_TEAM_INVITE:
+				$modIds[$recordId & ((1 << 30) - 1)] = true; // :InviteEditBit
+				break;
+			// NOTIFICATION_MOD_OWNERSHIP_TRANSFER_RESOLVED: cannot be batched, handled individually below. :IndividualTransferInfos
+			case NOTIFICATION_NEW_COMMENT:
+			case NOTIFICATION_MENTIONED_IN_COMMENT:
+			case NOTIFICATION_RESPONDED_TO_COMMENT:
+				$commentIds[$recordId] = true;
+				break;
+			case NOTIFICATION_WARNING_RECEIVED:
+				$warningIds[$recordId] = true;
+				break;
+			case NOTIFICATION_WARNING_ACKNOWLEDGED:
+				$userIds[$recordId] = true;
+				break;
+			case NOTIFICATION_ONEOFF_MALFORMED_RELEASE:
+				$releaseAssetIds[$recordId] = true;
+				break;
+		}
+	}
+
+	// @security: array keys are database integers, therefore sql inert when interpolated into IN().
+	if($modIds) {
+		$ids = implode(',', array_keys($modIds));
+		$modInfos = $con->getAssoc("SELECT m.modId, a.name AS modName, u.name AS username FROM mods m JOIN assets a ON a.assetId = m.assetId JOIN users u ON u.userId = a.createdByUserId WHERE m.modId IN ($ids)");
+	}
+
+	if($commentIds) {
+		$ids = implode(',', array_keys($commentIds));
+		$commentInfos = $con->getAssoc("SELECT c.commentId, a.name AS modName, u.name AS username FROM comments c JOIN assets a ON a.assetId = c.assetId JOIN users u ON u.userId = c.userId WHERE c.commentId IN ($ids)");
+	}
+
+	if($warningIds) {
+		$ids = implode(',', array_keys($warningIds));
+		$warningReasons = $con->getAssoc("SELECT actionId, reason FROM moderationRecords WHERE actionId IN ($ids)");
+	}
+
+	if($userIds) {
+		$ids = implode(',', array_keys($userIds));
+		$userNames = $con->getAssoc("SELECT userId, name FROM users WHERE userId IN ($ids)");
+	}
+
+	if($releaseAssetIds) {
+		$ids = implode(',', array_keys($releaseAssetIds));
+		$releaseModNames = $con->getAssoc("SELECT r.assetId, a.name FROM modReleases r JOIN mods m ON m.modId = r.modId JOIN assets a ON a.assetId = m.assetId WHERE r.assetId IN ($ids)");
+	}
+
+
 	foreach ($notifications as &$notification) {
+		$recordId = $notification['recordId'];
 		switch ($notification['kind']) {
 			case NOTIFICATION_NEW_RELEASE:
-				$cmt = $con->getRow(<<<SQL
-					SELECT a.name AS modName, u.name AS username
-					FROM mods m
-					JOIN assets a ON a.assetId = m.assetId
-					JOIN users u ON u.userId = a.createdByUserId
-					WHERE m.modId = ?
-				SQL, [$notification['recordId']]);
-
-				$notification['text'] = "{$cmt['username']} uploaded a new version of {$cmt['modName']}";
+				$info = $modInfos[$recordId];
+				$notification['text'] = "{$info['username']} uploaded a new version of {$info['modName']}";
 				break;
 
 			case NOTIFICATION_TEAM_INVITE:
-				$cmt = $con->getRow(<<<SQL
-					SELECT a.name AS modName, u.name AS username
-					FROM mods m
-					JOIN assets a ON a.assetId = m.assetId
-					JOIN users u ON u.userId = a.createdByUserId
-					WHERE m.modId = ? 
-				SQL, [intval($notification['recordId']) & ((1 << 30) - 1)]);  // :InviteEditBit
-
-				$notification['text'] = "{$cmt['username']} invited you to join the team of {$cmt['modName']}";
+				$info = $modInfos[$recordId & ((1 << 30) - 1)]; // :InviteEditBit
+				$notification['text'] = "{$info['username']} invited you to join the team of {$info['modName']}";
 				break;
 
 			case NOTIFICATION_MOD_OWNERSHIP_TRANSFER_REQUEST:
-				$cmt = $con->getRow(<<<SQL
-					SELECT a.name AS modName, u.name AS username
-					FROM mods m
-					JOIN assets a ON a.assetId = m.assetId
-					JOIN users u ON u.userId = a.createdByUserId
-					WHERE m.modId = ?
-				SQL, [$notification['recordId']]);
-
-				$notification['text'] = "{$cmt['username']} offered you ownership of {$cmt['modName']}";
+				$info = $modInfos[$recordId];
+				$notification['text'] = "{$info['username']} offered you ownership of {$info['modName']}";
 				break;
 
-			case NOTIFICATION_MOD_OWNERSHIP_TRANSFER_RESOLVED:
-				$modId = intval($notification['recordId']) & ((1 << 30) - 1);  // :PackedTransferSuccess
-				$cmt = $con->getRow(<<<SQL
+			case NOTIFICATION_MOD_OWNERSHIP_TRANSFER_RESOLVED: // :IndividualTransferInfos
+				$modId = $recordId & ((1 << 30) - 1); // :PackedTransferSuccess
+				$info = $con->getRow(<<<SQL
 					SELECT a.name AS modName, u.name AS username
 					FROM mods m
 					JOIN assets a ON a.assetId = m.assetId
-					JOIN (SELECT userId FROM notifications n WHERE kind = ? AND (n.recordId & ((1 << 30) - 1)) = ? ORDER BY created DESC LIMIT 1) ogn ON 1 = 1 -- :InviteEditBit
+					JOIN (SELECT userId FROM notifications n WHERE kind = ? AND (n.recordId & ((1 << 30) - 1)) = ? ORDER BY created DESC LIMIT 1) ogn ON 1 = 1
 					JOIN users u ON u.userId = ogn.userId
 					WHERE m.modId = ?
 				SQL, [NOTIFICATION_MOD_OWNERSHIP_TRANSFER_REQUEST, $modId, $modId]);
-
-				$verb = $notification['recordId'] & (1 << 30) ? 'accepted' : 'rejected'; // :PackedTransferSuccess
-
-				$notification['text'] = "{$cmt['username']} has $verb your ownership transfer of {$cmt['modName']}";
+				$verb = $recordId & (1 << 30) ? 'accepted' : 'rejected';
+				$notification['text'] = "{$info['username']} has $verb your ownership transfer of {$info['modName']}";
 				break;
 
 			case NOTIFICATION_NEW_COMMENT: case NOTIFICATION_MENTIONED_IN_COMMENT: case NOTIFICATION_RESPONDED_TO_COMMENT:
-				$cmt = $con->getRow(<<<SQL
-					SELECT a.name AS modName, u.name AS username
-					FROM comments c
-					JOIN assets a ON a.assetId = c.assetId
-					JOIN users u ON u.userId = c.userId
-					WHERE c.commentId = ?
-				SQL, [$notification['recordId']]);
-
+				$info = $commentInfos[$recordId];
 				switch ($notification['kind']) {
-					case NOTIFICATION_NEW_COMMENT: $notification['text'] = "{$cmt['username']} commented on {$cmt['modName']}"; break;
-					case NOTIFICATION_MENTIONED_IN_COMMENT: $notification['text'] = "{$cmt['username']} mentioned you in a comment on {$cmt['modName']}"; break;
-					case NOTIFICATION_RESPONDED_TO_COMMENT: $notification['text'] = "{$cmt['username']} responded to one of your comments on {$cmt['modName']}"; break;
+					case NOTIFICATION_NEW_COMMENT: $notification['text'] = "{$info['username']} commented on {$info['modName']}"; break;
+					case NOTIFICATION_MENTIONED_IN_COMMENT: $notification['text'] = "{$info['username']} mentioned you in a comment on {$info['modName']}"; break;
+					case NOTIFICATION_RESPONDED_TO_COMMENT: $notification['text'] = "{$info['username']} responded to one of your comments on {$info['modName']}"; break;
 				}
 				break;
 
 			case NOTIFICATION_MOD_LOCKED:
-				$modName = $con->getOne('SELECT name FROM mods m JOIN assets a ON a.assetId = m.assetId WHERE m.modId = ?', [$notification['recordId']]);
-				$notification['text'] = "Your mod '{$modName}' got locked by a moderator";
+				$info = $modInfos[$recordId];
+				$notification['text'] = "Your mod '{$info['modName']}' got locked by a moderator";
 				break;
 
 			case NOTIFICATION_MOD_UNLOCK_REQUEST:
-				$modName = $con->getOne('SELECT name FROM mods m JOIN assets a ON a.assetId = m.assetId WHERE m.modId = ?', [$notification['recordId']]);
-				$notification['text'] = "A review-request was issued for a mod locked by you ('{$modName}')";
+				$info = $modInfos[$recordId];
+				$notification['text'] = "A review-request was issued for a mod locked by you ('{$info['modName']}')";
 				break;
 
 			case NOTIFICATION_MOD_UNLOCKED:
-				$modName = $con->getOne('SELECT name FROM mods m JOIN assets a ON a.assetId = m.assetId WHERE m.modId = ?', [$notification['recordId']]);
-				$notification['text'] = "Your mod '{$modName}' got unlocked by a moderator";
+				$info = $modInfos[$recordId];
+				$notification['text'] = "Your mod '{$info['modName']}' got unlocked by a moderator";
 				break;
 
 			case NOTIFICATION_WARNING_RECEIVED:
 				$notification['text'] = "You have been issued a warning by a moderator. Dismiss this notification to dismiss and acknowledge the warning.";
-
-				$reason = $con->getOne('SELECT reason FROM moderationRecords WHERE actionId = ?', [$notification['recordId']]);
+				$reason = $warningReasons[$recordId];
 				addMessage('bg-warning permanent', <<<HTML
 					<h3 style='text-align: center;'>You have been issued a warning:</h3>
 					<p><blockquote>{$reason}</blockquote></p>
 					<p><small>Dismiss and acknowledge this by <a href="/notification/{$notification['notificationId']}">dismissing the notification</a>.</small></p>
 				HTML);
-
 				break;
 
 			case NOTIFICATION_WARNING_ACKNOWLEDGED:
-				$username = $con->getOne('SELECT name FROM users WHERE userId = ?', [$notification['recordId']]);
-				$notification['text'] = "{$username} has acknowledged your warning.";
+				$notification['text'] = "{$userNames[$recordId]} has acknowledged your warning.";
 				break;
 
 			case NOTIFICATION_ONEOFF_MALFORMED_RELEASE:
-				$modName = $con->getOne(<<<SQL
-					SELECT name
-					FROM mods m
-					JOIN modReleases r ON r.modId = m.modId
-					JOIN assets a ON a.assetId = m.assetId
-					WHERE r.assetId = ?
-				SQL, [$notification['recordId']]);
-				$notification['text'] = "A release of your mod '$modName' contains a file that has malformed information. Please resolve this issue.";
+				$notification['text'] = "A release of your mod '{$releaseModNames[$recordId]}' contains a file that has malformed information. Please resolve this issue.";
 				break;
 		}
 		$notification['link'] = "/notification/{$notification['notificationId']}";

--- a/list-mod.php
+++ b/list-mod.php
@@ -33,6 +33,7 @@ $selectedParams = [
 	'type'    => $filters['type'] ?? '',
 	'category'=> $filters['category'] ?? '',
 	'text'    => htmlSpecialChars($filters['text'] ?? ''),
+	'modid'   => htmlSpecialChars($filters['modid'] ?? ''),
 	'contributor' => !empty($filters['contributor'])
 		? [$filters['contributor'], $con->getOne('SELECT `name` FROM users WHERE `hash` = UNHEX(?)', [$filters['contributor']])]
 		: [],

--- a/templates/comment.tpl
+++ b/templates/comment.tpl
@@ -2,17 +2,21 @@
 	<div class="title">
 		<span><a style="text-decoration:none;" href="#cmt-{$comment['commentId']}"><i class="bx bx-link-alt"></i></a>
 		<a href="/show/user/{$comment['userHash']}">{htmlspecialchars($comment['username'])}</a>{if !empty($comment["flairCode"])} <small class="flair flair-{$comment['flairCode']}"></small>{/if}{if $comment['isBanned']}&nbsp;<span style="color:red;">[currently restricted]</span>{/if}, {fancyDate($comment['created'])} {if $comment['contentLastModified']}(modified {fancyDate($comment['contentLastModified'])}{if $comment['lastModaction'] == MODACTION_KIND_EDIT} by a moderator{/if}){/if}{if $comment['lastModaction'] == MODACTION_KIND_DELETE} (deleted by moderator){/if}</span>
-			{if !empty($user)}
-					{if $comment["userId"] == $user["userId"]}
-						{if !$comment['deleted']}
-							<span class="buttons strikethrough-when-banned strikethrough-when-readonly">(<a href="#r" onclick="return false;">respond</a>&nbsp;<a href="#e" onclick="return false;">edit</a>&nbsp;<a href="#d" onclick="return false;">delete</a>)</span>
-						{/if}
-					{elseif canModerate($comment['userId'], $user) && !($comment["userId"] == $user["userId"])}
-							<span class="buttons strikethrough-when-banned strikethrough-when-readonly">(<a href="#r" onclick="return false;">respond</a>&nbsp;{if !$comment['deleted']}<a href="#e" onclick="return false;">edit</a>&nbsp;<a href="#d" onclick="return false;">delete</a>&nbsp;{/if}<a href="/moderate/user/{$comment['userHash']}?source-comment={$comment['commentId']}">moderate user</a>)</span>
-					{elseif $asset['createdByUserId'] == $user['userId'] && !$comment['deleted']}
-							<span class="buttons strikethrough-when-banned strikethrough-when-readonly">(<a href="#r" onclick="return false;">respond</a>&nbsp;<a href="#d" onclick="return false;">delete</a>)</span>
+		{if !empty($user)}
+			<span class="buttons strikethrough-when-banned strikethrough-when-readonly">
+				{if $comment["userId"] == $user["userId"]}
+					{if !$comment['deleted']}
+						(<a href="#r" onclick="return false;">respond</a>&nbsp;<a href="#e" onclick="return false;">edit</a>&nbsp;<a href="#d" onclick="return false;">delete</a>)
 					{/if}
-			{/if}
+				{elseif canModerate($comment['userId'], $user) && !($comment["userId"] == $user["userId"])}
+						(<a href="#r" onclick="return false;">respond</a>&nbsp;{if !$comment['deleted']}<a href="#e" onclick="return false;">edit</a>&nbsp;<a href="#d" onclick="return false;">delete</a>&nbsp;{/if}<a href="/moderat{$comment['userHash']}?source-comment={$comment['commentId']}">moderate user</a>)</span>
+				{elseif $asset['createdByUserId'] == $user['userId'] && !$comment['deleted']}
+						(<a href="#r" onclick="return false;">respond</a>&nbsp;<a href="#d" onclick="return false;">delete</a>)
+				{else}
+						(<a href="#r" onclick="return false;">respond</a>)
+				{/if}
+			</span>
+		{/if}
 	</div>
 	{if $comment['responseTo'] !== $comment['commentId']}<a class="reference" href="#cmt-{$comment['responseTo']}">@{htmlspecialchars($comment['parentUserName'])}: <span>{htmlspecialchars($comment['parentText'])}</span></a>{/if}
 	<div class="body">{postprocessCommentHtml($comment['text'])}</div>

--- a/templates/list-mod.tpl
+++ b/templates/list-mod.tpl
@@ -12,6 +12,10 @@
 			<input type="text" name="text" value="{$selectedParams['text']}" style="width:12em;">
 		</span>
 
+		<span data-label="Mod ID">
+			<input type="text" name="modid" value="{$selectedParams['modid']}" style="width:10em;">
+		</span>
+
 		<span data-label="Side">
 			<select name="side" style="width:10em;">
 				<option value="">Any</option>

--- a/templates/show-mod.tpl
+++ b/templates/show-mod.tpl
@@ -58,8 +58,16 @@
 		</div>
 	{/if}
 
-	<input class="tab-trigger" id="tab-description" type="radio" name="tab" autocomplete="off">
+	<input class="tab-trigger" id="tab-description" type="radio" name="tab" checked="true" autocomplete="off">
 	<input class="tab-trigger" id="tab-files" type="radio" name="tab" autocomplete="off">
+
+	<script nonce="{$cspNonce}">
+		document.getElementById(location.hash !== '#tab-files' ? 'tab-description' : 'tab-files').checked = true;
+		window.addEventListener('pageshow', e => {
+			if(e.persisted) document.getElementById(location.hash === '#tab-files' ? 'tab-files' : 'tab-description').checked = true;
+		});
+	</script>
+
 
 	<ul class="tabs no-mark">
 		<li><label for="tab-description" onclick="location.hash = 'tab-description'">Description</label></li>
@@ -83,7 +91,6 @@
 
 	<div class="tab-container">
 		<div class="tab-content description">
-			<script nonce="{$cspNonce}">if(location.hash !== '#tab-files') document.getElementById('tab-description').checked = true;</script>
 			<div style="float: right; margin-bottom: 1em;">
 				{if isset($user) && canEditAsset($asset, $user)}
 					<a class="button large shine strikethrough-when-banned strikethrough-when-readonly" href="/edit/mod/?assetid={$asset['assetId']}">Edit</a>&nbsp;
@@ -182,7 +189,6 @@
 		</div>
 
 		<div class="tab-content files">
-			<script nonce="{$cspNonce}">if(location.hash === '#tab-files') document.getElementById('tab-files').checked = true;</script>
 			<div style="float: right; margin-bottom: 1em;">
 				{if isset($user) && canEditAsset($asset, $user)}
 					<a class="button large shine strikethrough-when-banned strikethrough-when-readonly" href="/edit/release/?modid={$asset['modId']}">Add release</a>


### PR DESCRIPTION
- Mod search only matches names, summaries, and descriptions.
- Users with an identifier from a log or modinfo.json cannot find the mod.
- Adds a "Mod ID" input that exact-matches `modReleases.identifier`.
- Excludes retracted releases via LEFT JOIN on retractions table.
- Relies on existing GROUP BY for deduplication.
  
Closes #50

<img width="1889" height="702" alt="modid_pr" src="https://github.com/user-attachments/assets/9fa5616e-d860-42d9-be62-32355ef5c9f5" />
