### PR TITLE
Add separate Mod ID search filter

### DIFF
--- a/db/134_migrate.sql
+++ b/db/134_migrate.sql
@@ -1,0 +1,4 @@
+-- Add standalone index on identifier for mod ID search lookups.
+-- The existing UNIQUE(modId, identifier, version) index cannot be used
+-- for queries that filter only by identifier.
+CREATE INDEX `idx_identifier` ON `modReleases` (`identifier`);

--- a/list-mod.php
+++ b/list-mod.php
@@ -2,6 +2,28 @@
 
 include($config["basepath"] . "lib/search-mods.php");
 
+// Mod ID search: identifier uniquely identifies a mod, so redirect directly to its page.
+if(!empty($_REQUEST['modid'])) {
+	$modid = trim($_REQUEST['modid']);
+	$retractionFilter = canModerate(null, $user) ? '' : 'AND mrr.releaseId IS NULL';
+	$assetId = $con->getOne("
+		SELECT m.assetId
+		FROM modReleases mr
+		JOIN mods m ON m.modId = mr.modId
+		LEFT JOIN modReleaseRetractions mrr ON mrr.releaseId = mr.releaseId
+		WHERE mr.identifier = ?
+		$retractionFilter
+		LIMIT 1
+	", [$modid]);
+
+	if($assetId) {
+		header("Location: /show/mod/$assetId");
+		exit();
+	}
+
+	addMessage(MSG_CLASS_ERROR, "No mod found with identifier '$modid'.", true);
+}
+
 if(isset($_GET['paging'])) {
 	if($paramError = validateModSearchInputs($searchParams, true)) {
 		http_response_code(HTTP_BAD_REQUEST);

--- a/templates/list-mod.tpl
+++ b/templates/list-mod.tpl
@@ -8,8 +8,12 @@
 		<input type="hidden" name="sortby" value="{$selectedParams['order'][0]}">
 		<input type="hidden" name="sortdir" value="{$selectedParams['order'][1][0]}">
 
-		<span data-label="Text" title="Searches mod names, summaries and descriptions.">
+		<span id="search-box" data-label="Text" title="Searches mod names, summaries and descriptions.">
 			<input type="text" name="text" value="{$selectedParams['text']}" style="width:12em;">
+		</span>
+
+		<span data-label="ID">
+			<label class="toggle" style="border-radius:0;"><input type="checkbox" id="modid-toggle" style="border-radius:0;"></label>
 		</span>
 
 		<span data-label="Side">
@@ -154,6 +158,19 @@
 		$(() => \{
 			attachRemoteSearchHandler(document.getElementById('contributor-box'));
 			attachRemoteSearchHandler(document.getElementById('tags-box'));
+
+			const modidToggle = document.getElementById('modid-toggle');
+			const searchInput = document.querySelector('#search-box input[type="text"]');
+			const otherFilters = document.querySelectorAll('select[name="side"], #tags-box select, #contributor-box select, select[name="c"], select[name="t"], select[name="mv"], select[name="gv[]"]');
+
+			modidToggle.addEventListener('change', function() {
+				const active = this.checked;
+				searchInput.name = active ? 'modid' : 'text';
+				otherFilters.forEach(el => {
+					el.disabled = active;
+					$(el).trigger('chosen:updated');
+				});
+			});
 		});
 
 		let fetchCursor = '{$fetchCursorJS}';


### PR DESCRIPTION
- Mod search only matches names, summaries, and descriptions.
- Users with an identifier from a log or modinfo.json cannot find the mod.
- Adds a "Mod ID" input that exact-matches modReleases.identifier.
- Excludes retracted releases via LEFT JOIN on retractions table.
- Relies on existing GROUP BY for deduplication.

Closes https://github.com/anegostudios/vsmoddb/issues/50

<img width="1889" height="702" alt="modid_pr" src="https://github.com/user-attachments/assets/0b83f714-0495-4dd9-b0aa-5188afb80dec" />
