### PR TITLE
Add GET /api/v2/mods/{identifier}/releases/latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,29 @@ String example: http://mods.vintagestory.at/api/mod/carrycapacity
 
 
 ### /api/v2/mods/{modid}/releases
-- `get`: Path arg `{modid}`
-	- `400`: Not implemented
+- `get`: Path arg `{modid}` (numeric)
+	- `200`: json array of non-retracted release IDs (ordered by version descending, empty if mod has no releases or does not exist):
+		```json
+		{"data": [456, 123, 89]}
+		```
+
+### /api/v2/mods/{modid}/releases/latest
+- `get`: Path arg `{modid}` (numeric)
+	- `404`: No non-retracted release found.
+	- `200`: json of the latest non-retracted release:
+		```json
+		{
+			"data": {
+				"releaseId": 456,
+				"identifier": "carrycapacity",
+				"version": "1.2.3",
+				"fileName": "carrycapacity-1.2.3.zip",
+				"fileUrl": "/download/789/carrycapacity-1.2.3.zip",
+				"compatibleGameVersions": ["1.20.7", "1.20.6"],
+				"created": "2025-01-15 12:00:00"
+			}
+		}
+		```
 
 ### /api/v2/mods/{modid}/releases/all
 - `get`: Path arg `{modid}`
@@ -144,9 +165,24 @@ String example: http://mods.vintagestory.at/api/mod/carrycapacity
 ### /api/v2/mods/{modid}/releases/{releaseid}
 - `get`
 	- Args:
-		- Path arg `{modid}`
-		- Path arg `{releaseid}`
-	- `400`: Not implemented
+		- Path arg `{modid}` (numeric)
+		- Path arg `{releaseid}` (numeric)
+	- `404`: Release not found.
+	- `200`: json of the release (same shape as /latest, plus `retractionReason` if retracted):
+		```json
+		{
+			"data": {
+				"releaseId": 456,
+				"identifier": "carrycapacity",
+				"version": "1.2.3",
+				"fileName": "carrycapacity-1.2.3.zip",
+				"fileUrl": "/download/789/carrycapacity-1.2.3.zip",
+				"compatibleGameVersions": ["1.20.7", "1.20.6"],
+				"created": "2025-01-15 12:00:00",
+				"retractionReason": "..."
+			}
+		}
+		```
 - `post` `auth` `at`
 	- Args:
 		- Path arg `{modid}`

--- a/lib/api/public/mods.php
+++ b/lib/api/public/mods.php
@@ -235,4 +235,92 @@ switch($urlparts[0]) {
 		unset($r);
 
 		good(['data' => $result]);
+
+	default:
+		// /api/v2/mods/{modId}/releases[/{releaseId}|/latest]
+		$modId = filter_var($urlparts[0], FILTER_VALIDATE_INT);
+		if($modId === false) break;
+		if(!isset($urlparts[1]) || $urlparts[1] !== 'releases') break;
+
+		validateMethod('GET');
+
+		$releaseSegment = $urlparts[2] ?? null;
+
+		if($releaseSegment === null) {
+			// GET /api/v2/mods/{modId}/releases — list release IDs
+			$releases = $con->getAll(<<<SQL
+				SELECT r.releaseId
+				FROM modReleases r
+				LEFT JOIN modReleaseRetractions rr ON rr.releaseId = r.releaseId
+				WHERE r.modId = ? AND rr.reason IS NULL
+				ORDER BY r.version DESC
+			SQL, [$modId]);
+
+			good(['data' => array_map(fn($r) => intval($r['releaseId']), $releases)]);
+		}
+
+		if($releaseSegment === 'latest') {
+			// GET /api/v2/mods/{modId}/releases/latest — latest non-retracted release
+			$release = $con->getRow(<<<SQL
+				SELECT r.releaseId, r.identifier, r.version, r.created,
+					f.fileId, f.name,
+					GROUP_CONCAT(cgv.gameVersion ORDER BY cgv.gameVersion DESC SEPARATOR ';') AS compatibleGameVersions
+				FROM modReleases r
+				LEFT JOIN files f ON f.assetId = r.assetId
+				LEFT JOIN modReleaseRetractions rr ON rr.releaseId = r.releaseId
+				LEFT JOIN modReleaseCompatibleGameVersions cgv ON cgv.releaseId = r.releaseId
+				WHERE r.modId = ? AND rr.reason IS NULL
+				GROUP BY r.releaseId
+				ORDER BY r.version DESC
+				LIMIT 1
+			SQL, [$modId]);
+
+			if(!$release) fail(HTTP_NOT_FOUND, ['reason' => 'No non-retracted release found.']);
+
+			good(['data' => [
+				'releaseId'  => intval($release['releaseId']),
+				'identifier' => $release['identifier'],
+				'version'    => formatSemanticVersion(intval($release['version'])),
+				'fileName'   => $release['name'],
+				'fileUrl'    => $release['fileId'] ? formatDownloadTrackingUrl($release) : null,
+				'compatibleGameVersions' => $release['compatibleGameVersions']
+					? array_map(fn($v) => formatSemanticVersion(intval($v)), explode(';', $release['compatibleGameVersions']))
+					: [],
+				'created'    => $release['created'],
+			]]);
+		}
+
+		// GET /api/v2/mods/{modId}/releases/{releaseId}
+		$releaseId = filter_var($releaseSegment, FILTER_VALIDATE_INT);
+		if($releaseId === false) break;
+
+		$release = $con->getRow(<<<SQL
+			SELECT r.releaseId, r.identifier, r.version, r.created,
+				f.fileId, f.name,
+				rr.reason AS retractionReason,
+				GROUP_CONCAT(cgv.gameVersion ORDER BY cgv.gameVersion DESC SEPARATOR ';') AS compatibleGameVersions
+			FROM modReleases r
+			LEFT JOIN files f ON f.assetId = r.assetId
+			LEFT JOIN modReleaseRetractions rr ON rr.releaseId = r.releaseId
+			LEFT JOIN modReleaseCompatibleGameVersions cgv ON cgv.releaseId = r.releaseId
+			WHERE r.releaseId = ? AND r.modId = ?
+			GROUP BY r.releaseId
+		SQL, [$releaseId, $modId]);
+
+		if(!$release) fail(HTTP_NOT_FOUND, ['reason' => 'Release not found.']);
+
+		$data = [
+			'releaseId'  => intval($release['releaseId']),
+			'identifier' => $release['identifier'],
+			'version'    => formatSemanticVersion(intval($release['version'])),
+			'fileName'   => $release['name'],
+			'fileUrl'    => $release['fileId'] ? formatDownloadTrackingUrl($release) : null,
+			'compatibleGameVersions' => $release['compatibleGameVersions']
+				? array_map(fn($v) => formatSemanticVersion(intval($v)), explode(';', $release['compatibleGameVersions']))
+				: [],
+			'created'    => $release['created'],
+		];
+		if($release['retractionReason']) $data['retractionReason'] = $release['retractionReason'];
+
+		good(['data' => $data]);
 }


### PR DESCRIPTION
- No efficient way to get the latest release of a mod by identifier.
- The existing install-information endpoint requires a game version or a known mod version to query against.
- Adds a simple endpoint that returns the latest non-retracted release for a given identifier string (from modinfo.json). 
- Single query, LIMIT 1, includes compatible game versions.
- Returns 404 if no release exists.
- Documented in README.

Closes #90

**200 — GET /api/v2/mods/carrycapacity/releases/latest**
```
{
"data": {
    "identifier": "carrycapacity",
    "version": "1.2.3",
    "releaseId": 456,
    "fileName": "carrycapacity-1.2.3.zip",
    "fileUrl": "/download/789/carrycapacity-1.2.3.zip",
    "compatibleGameVersions": ["1.20.7", "1.20.6"],
    "created": "2025-01-15 12:00:00"
    }
}
```

**404 — GET /api/v2/mods/nonexistent/releases/latest**
```
{"reason": "No release found for this identifier."}
```