### PR TITLE
fix: missing return in retracted release check, unlink temp file

### DIFF
--- a/lib/fileupload.php
+++ b/lib/fileupload.php
@@ -56,7 +56,7 @@ function processFileUpload($file, $assetTypeId, $parentAssetId, $parentModId) {
 	if ($parentAssetId) { // Editing existing releases or adding mod images
 		if($assetTypeId === ASSETTYPE_RELEASE) {
 			if($reason = $con->getOne('SELECT rr.reason FROM modReleases r LEFT JOIN modReleaseRetractions rr ON rr.releaseId = r.releaseId WHERE r.assetId = ?', [$parentAssetId])) {
-				array("status" => "error", "errormessage" => 'Release has been retracted: '.textContent($reason)); 
+				return array("status" => "error", "errormessage" => 'Release has been retracted: '.textContent($reason)); 
 			}
 		}
 		$asset = $con->getRow("select assetTypeId, assetId, createdByUserId from assets where assetId = ?", array($parentAssetId));
@@ -165,7 +165,7 @@ function processFileUpload($file, $assetTypeId, $parentAssetId, $parentModId) {
 		}
 	}
 
-	//TODO(Rennorb) @perf: unlink $localPath here?
+	unlink($localPath);
 
 	return $data;
 }


### PR DESCRIPTION
Two small fixes in `processFileUpload`:

--

**1. Dead retraction guard (line 58)**

```php
if($reason = $con->getOne(...)) {
    array("status" => "error", ...); // missing return
}
```
Without `return`, drag-and-drop uploads via `edit-uploadfile.php` can push files to retracted releases. The file ends up orphaned on CDN since `edit-release.php` won't save it, but it still wastes storage and bypasses the intended guard.

--

**2. Temp file not unlinked on success (line 168)**

Resolves the existing `@perf` TODO. After CDN upload the temp file (up to 40MB for releases) lingered until request end.