### PR TITLE
perf: eliminate subquery in download counter update

### DIFF
--- a/download.php
+++ b/download.php
@@ -7,7 +7,7 @@ $fileId = intval($_GET['fileid'] ?? $urlparts[1] ?? 0);
 if($fileId === 0) showErrorPage(HTTP_BAD_REQUEST, 'Missing fileid.');
 
 $file = $con->getRow(<<<SQL
-	SELECT f.assetId, f.cdnPath, f.name, rr.reason AS retractionReason
+	SELECT f.assetId, f.cdnPath, f.name, r.modId, rr.reason AS retractionReason
 	FROM files f
 	LEFT JOIN modReleases r ON r.assetId = f.assetId
 	LEFT JOIN modReleaseRetractions rr ON rr.releaseId = r.releaseId
@@ -27,7 +27,9 @@ if(!DB_READONLY) {
 		$con->execute('INSERT INTO fileDownloadTracking (fileId, ipAddress) VALUES (?, ?)', $identifier);
 
 		$con->execute('UPDATE files SET downloads = downloads + 1 WHERE fileId = ?', [$fileId]);
-		$con->execute('UPDATE mods  SET downloads = downloads + 1 WHERE modId = (SELECT r.modId FROM modReleases r WHERE r.assetId = ?)', [$file['assetId']]);
+		if($file['modId']) {
+			$con->execute('UPDATE mods SET downloads = downloads + 1 WHERE modId = ?', [$file['modId']]);
+		}
 
 		$con->completeTrans();
 	}


### PR DESCRIPTION
The initial query in `download.php` already JOINs `modReleases` but doesn't select `modId`. The counter update then re-derives it via subquery:

```php
UPDATE mods SET downloads = downloads + 1
WHERE modId = (SELECT r.modId FROM modReleases r WHERE r.assetId = ?)
```

Fix: select `r.modId` in the initial query, use it directly. Guard with `if` for non-release files where `modId` is NULL (LEFT JOIN).

### Queries per unique download

|  | Before | After |
|--|:------:|:-----:|
| SELECT file + retraction check | 1 | 1 |
| SELECT tracking | 1 | 1 |
| INSERT tracking | 1 | 1 |
| UPDATE files counter | 1 | 1 |
| UPDATE mods counter | 1 (with subquery) | 1 (direct) or 0 |
| **Total statements** | **5** | **5** (or 4 for non-release files) |
| **Total query complexity** | 5 + 1 nested SELECT | **5 flat** |

~170k unique downloads/day (from `fileDownloadTracking` rows in 72h; sum of all `trendingpoints` via `/api/mods` = 523k; formula in `cmd-updatetrending.php`: `downloads_72h + 5*comments_72h`; comments contribute <2%).

That's ~170k unnecessary subqueries/day eliminated.