### PR TITLE
Replace endsWith/startsWith with PHP 8 builtins

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@ if(empty($urlpath))  $urlpath = 'home';
 
 // @security: Filter out directory traversal segments.
 // Just discard them completely, they are not used in any actual application.
-$urlparts = array_filter(explode('/', $urlpath), fn($s) => !startsWith($s, '.'));
+$urlparts = array_filter(explode('/', $urlpath), fn($s) => !str_starts_with($s, '.'));
 
 if($urlparts[0] === 'api') { // :ReservedUrlPrefixes
 	array_shift($urlparts);

--- a/lib/api/v1/functions.php
+++ b/lib/api/v1/functions.php
@@ -138,11 +138,11 @@ function listMod($modid)
 
 function parseVersion($rawValue)
 {
-	return startsWith($rawValue, '-') ? intval(substr($rawValue, 1)) : compileSemanticVersion($rawValue);
+	return str_starts_with($rawValue, '-') ? intval(substr($rawValue, 1)) : compileSemanticVersion($rawValue);
 }
 function parsePrimaryVersion($rawValue)
 {
-	return startsWith($rawValue, '-') ? intval(substr($rawValue, 1)) & VERSION_MASK_PRIMARY : compilePrimaryVersion($rawValue);
+	return str_starts_with($rawValue, '-') ? intval(substr($rawValue, 1)) & VERSION_MASK_PRIMARY : compilePrimaryVersion($rawValue);
 }
 
 function listMods()

--- a/lib/cdn/bunny.php
+++ b/lib/cdn/bunny.php
@@ -202,7 +202,7 @@ function bunny_pullLogsAndUpdateDownloadNumbers($date)
 		if($statuscode != 200) continue;
 
 		$url = parse_url($parts[5]);
-		if(!startsWith($url['query'], '?dl=')) continue;
+		if(!str_starts_with($url['query'] ?? '', '?dl=')) continue;
 		
 		$cdnPath = substr($url['path'], 1);
 		$time = intval($parts[2]) / 1000;

--- a/lib/cdn/none.php
+++ b/lib/cdn/none.php
@@ -65,7 +65,7 @@ function formatCdnUrl($file, $filenamePostfix = '') {
 	// Evil hackery to test for the case where we use this internally to feed get_file_contents, where we cannot just pass a url fragment.
 	$trace = debug_backtrace(0, 2);
 	$caller = $trace[0]['file'];
-	if(endsWith($caller, 'edit-mod.php')) {
+	if(str_ends_with($caller, 'edit-mod.php')) {
 		global $config;
 		return $config['basepath'].'files/'.substr($url, 8 /* /cdnfile */);
 	}

--- a/lib/core.php
+++ b/lib/core.php
@@ -56,16 +56,6 @@ function dump_die($var)
 
 
 
-function endsWith($string, $part) //TODO(Rennorb)  @perf: use str_ends_with() instead, if we can get a newer version of php
-{
-	return mb_strlen($string) >= mb_strlen($part) && mb_substr($string, mb_strlen($string) - mb_strlen($part)) == $part;
-}
-
-function startsWith($string, $part) //TODO(Rennorb)  @perf: use str_starts_with() instead, if we can get a newer version of php
-{
-	return mb_substr($string, 0, mb_strlen($part)) == $part;
-}
-
 function contains($string, $part)
 {
 	return mb_strstr($string, $part) !== false;
@@ -345,7 +335,7 @@ function stripQueryParam($query, $paramname)
 {
 	$params = explode('&', $query);
 	$s = $paramname.'=';
-	$params = array_filter($params, fn($p) => !startsWith($p, $s));
+	$params = array_filter($params, fn($p) => !str_starts_with($p, $s));
 	return implode('&', $params);
 }
 
@@ -524,7 +514,7 @@ function parseSqlDateTime($str)
 function formatDateWhichMightBeForever($date, $format = "M jS Y, H:i:s", $forevertext = "forever")
 {
 	$year = $date->format("Y"); // unfortunately no way to get the year directly.
-	return startsWith($year, "9999") ? $forevertext : $date->format($format);
+	return str_starts_with($year, "9999") ? $forevertext : $date->format($format);
 }
 
 /**
@@ -829,7 +819,7 @@ function _inflateLink($link, $wrapUnmatchedLink)
 
 	$urlParts = parse_url($link);
 	$path = $urlParts['path'] ?? '';
-	$relAttr = empty($urlParts['host']) || endsWith($urlParts['host'], 'vintagestory.at') ? '' : ' rel="nofollow external"';
+	$relAttr = empty($urlParts['host']) || str_ends_with($urlParts['host'], 'vintagestory.at') ? '' : ' rel="nofollow external"';
 
 	$lastDot = strrpos($path, '.');
 	if($lastDot !== false && $lastDot + 1 < strlen($path)) {

--- a/show-mod.php
+++ b/show-mod.php
@@ -74,7 +74,7 @@ $files = $con->getAll('SELECT * FROM files WHERE assetId = ? AND fileId NOT IN (
 */
 if($asset['hasLegacyLogo']) {
 	splitOffExtension($asset['logoUrl'], $base, $ext);
-	if(endsWith($base, '_480_320')) {
+	if(str_ends_with($base, '_480_320')) {
 		$legacyLogoPath = substr($base, 0, strlen($base) - 8).'.'.$ext;
 		foreach ($files as $k => $file) {
 			if($file['cdnPath'] === $legacyLogoPath) {


### PR DESCRIPTION
Resolves TODO(Rennorb) in core.php.

Replaces the mb_* wrappers with native str_ends_with/str_starts_with (available since PHP 8.0). All call sites only ever pass ASCII needles, so byte-level comparison is correct.

Also guards against undefined array key in bunny.php where parse_url may omit the query component.