### PR TITLE
Extract search limit clamp to config constant

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -36,6 +36,7 @@ if (strstr($_SERVER["SERVER_NAME"], "mods.vintagestory.stage")) {
 
 	_define_default("MOD_SEARCH_INITIAL_RESULTS", 10);
 	_define_default("MOD_SEARCH_PAGE_SIZE", 10);
+	_define_default("MOD_SEARCH_MAX_LIMIT", 20);
 
 	_define_default("DOWNLOAD_DEDUPLICATION_TIMESPAN", 60); // seconds
 } else {
@@ -53,6 +54,7 @@ if (strstr($_SERVER["SERVER_NAME"], "mods.vintagestory.stage")) {
 
 	_define_default("MOD_SEARCH_INITIAL_RESULTS", 200);
 	_define_default("MOD_SEARCH_PAGE_SIZE", 200);
+	_define_default("MOD_SEARCH_MAX_LIMIT", 20);
 
 	_define_default("DOWNLOAD_DEDUPLICATION_TIMESPAN", 24*3600); // seconds
 }

--- a/lib/search-mods.php
+++ b/lib/search-mods.php
@@ -140,10 +140,9 @@ function validateModSearchInputs(&$outParams, $trimText)
 		$outParams['filters']['majorversion'] = $majorversion;
 	}
 
-	//TODO(Rennorb) @cleanup: these limits are arbitrary and should probably be outside of this function.
 	if(!empty($_REQUEST['limit'])) {
 		$limit = intval($_REQUEST['limit']);
-		$clampedLimit = max(1, min($limit, 20));
+		$clampedLimit = max(1, min($limit, MOD_SEARCH_MAX_LIMIT));
 		if($limit !== $clampedLimit) {
 			return "Invalid entry limit: '{$_REQUEST['limit']}'";
 		}


### PR DESCRIPTION
Resolves TODO(Rennorb) in search-mods.php. Moves the hardcoded max limit to MOD_SEARCH_MAX_LIMIT, following the existing _define_default pattern.