### PR TITLE
Replace custom contains() and strstr() with native str_contains()

### DIFF
--- a/edit-mod.php
+++ b/edit-mod.php
@@ -211,7 +211,7 @@ else if(!empty($_POST['save'])) {
 	if($textLen > 65535) { // TEXT column max length in assets.text
 		$sizeKb = floor($textLen / 1024);
 		$reason = "Excessive size ({$sizeKb}KB).";
-		if(contains($mod['text'], 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
+		if(str_contains($mod['text'], 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
 		addMessage(MSG_CLASS_ERROR, $reason);
 	}
 

--- a/edit-release.php
+++ b/edit-release.php
@@ -140,7 +140,7 @@ else if(!empty($_POST['save'])) {
 		if($textLen > 65535) { // TEXT column max length in assets.text
 			$sizeKb = floor($textLen / 1024);
 			$reason = "Excessive size ({$sizeKb}KB).";
-			if(contains($newData['text'], 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
+			if(str_contains($newData['text'], 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
 			addMessage(MSG_CLASS_ERROR, $reason);
 		}
 	}

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ include("lib/config.php");
 if(CDN === 'none') include("lib/core.php");
 
 if (!empty($_SERVER['HTTP_ACCEPT']) && $_SERVER['REQUEST_METHOD'] == "GET") {
-	if(!strstr($_SERVER['HTTP_ACCEPT'], "text/html") && !strstr($_SERVER['HTTP_ACCEPT'], "application/json") && $_SERVER['HTTP_ACCEPT'] != "*/*") exit("not an image");
+	if(!str_contains($_SERVER['HTTP_ACCEPT'] ?? '', "text/html") && !str_contains($_SERVER['HTTP_ACCEPT'] ?? '', "application/json") && ($_SERVER['HTTP_ACCEPT'] ?? '') != "*/*") exit("not an image");
 }
 
 // This is the more desirable point to initialize.

--- a/lib/api/authenticated/comments.php
+++ b/lib/api/authenticated/comments.php
@@ -28,7 +28,7 @@ switch($_SERVER['REQUEST_METHOD']) {
 		if($textLen > 65535) { // TEXT column max length in comments.text
 			$sizeKb = floor($textLen / 1024);
 			$reason = "Excessive size ({$sizeKb}KB).";
-			if(contains($commentHtml, 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
+			if(str_contains($commentHtml, 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
 			fail(HTTP_BAD_REQUEST, ['reason' => $reason]);
 		}
 

--- a/lib/api/authenticated/mods.php
+++ b/lib/api/authenticated/mods.php
@@ -46,7 +46,7 @@ switch($urlparts[1]) {
 				if($textLen > 65535) { // TEXT column max length in comments.text
 					$sizeKb = floor($textLen / 1024);
 					$reason = "Excessive size ({$sizeKb}KB).";
-					if(contains($commentHtml, 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
+					if(str_contains($commentHtml, 'src="data:image')) $reason .= " You cannot paste large images directly. If you need a large image, upload it to an external site and link to that.";
 					fail(HTTP_BAD_REQUEST, ['reason' => $reason]);
 				}
 

--- a/lib/config.php
+++ b/lib/config.php
@@ -17,7 +17,7 @@ function _define_default($name, $default)
 
 // If you want to set up a local installation, I recommend
 // adding "127.0.0.1	mods.vintagestory.stage"  to your hosts file
-if (strstr($_SERVER["SERVER_NAME"], "mods.vintagestory.stage")) {
+if (str_contains($_SERVER["SERVER_NAME"], "mods.vintagestory.stage")) {
 	$filepath = $config["basepath"] . "lib/config.dev.php";
 	if (file_exists($filepath)) {
 		include($filepath);

--- a/lib/core.php
+++ b/lib/core.php
@@ -66,11 +66,6 @@ function startsWith($string, $part) //TODO(Rennorb)  @perf: use str_starts_with(
 	return mb_substr($string, 0, mb_strlen($part)) == $part;
 }
 
-function contains($string, $part)
-{
-	return mb_strstr($string, $part) !== false;
-}
-
 /** Splits a string at a separator, but at most once.
  * If the separator is not found the left string contains the whole input, and the right string is empty.
  * @param string $string

--- a/lib/mod.php
+++ b/lib/mod.php
@@ -166,7 +166,7 @@ function updateModTags($modId, $oldTags, $newTagsIds)
 		}
 
 		if ($addedNamesFolded) {
-			$s = contains($addedNamesFolded, ',') ? 's' : '';
+			$s = str_contains($addedNamesFolded, ',') ? 's' : '';
 			$changes[] = "Added tag{$s} '$addedNamesFolded'.";
 		}
 	}

--- a/lib/notification.php
+++ b/lib/notification.php
@@ -2,7 +2,7 @@
 
 function goBackOrRootFallback()
 {
-	forceRedirect(!contains($_SERVER['HTTP_REFERER'] ?? '', 'notification/') ? $_SERVER['HTTP_REFERER'] : '/');
+	forceRedirect(!str_contains($_SERVER['HTTP_REFERER'] ?? '', 'notification/') ? $_SERVER['HTTP_REFERER'] : '/');
 }
 
 if (empty($user)) {

--- a/tests/api-v1.php
+++ b/tests/api-v1.php
@@ -263,7 +263,7 @@ final class ApiV1Test extends TestCase {
 		set_error_handler(function($errno, $errstr) {
 			// Suppress that error, its to complicated to "properly" avoid it.
 			// Would need to isolate the cache control header somehow, and thats not worth it.
-			return contains($errstr, 'Cannot modify header information');
+			return str_contains($errstr, 'Cannot modify header information');
 		}, E_WARNING);
 		$data = apiGet('changelogs');
 		restore_error_handler();


### PR DESCRIPTION
Same pattern as #120. Removes the mb_strstr wrapper — all call sites use ASCII needles.

Also adds null coalescing for HTTP_ACCEPT which may be absent.

Tested: Accept header routing (image/png → early exit, text/html → renders, */* → renders), notification redirect, config environment detection. Behavior identical to before.