### PR TITLE
fix: require active category selection for new mods

### DIFF
--- a/edit-mod.php
+++ b/edit-mod.php
@@ -70,7 +70,7 @@ else { // New mod
 		'modId'           => 0,
 		'assetTypeId'     => ASSETTYPE_MOD,
 		'statusId'        => STATUS_DRAFT,
-		'category'        => CATEGORY_GAME_MOD,
+		'category'        => null,
 		'side'            => 'both',
 		'name'            => '',
 		'summary'         => '',
@@ -149,8 +149,8 @@ else if(!empty($_POST['save'])) {
 	}
 
 	$mod['category'] = intval($_POST['category']);
-	if(!in_array($mod['category'], array_keys($modCategories), true)) {
-		addMessage(MSG_CLASS_WARN, "The new mod category is not valid and has been reset.");
+	if($_POST['category'] === '' || !in_array($mod['category'], array_keys($modCategories), true)) {
+		addMessage(MSG_CLASS_WARN, "The mod category is not valid.");
 		$mod['category'] = $oldModData['category'];
 	}
 

--- a/templates/edit-mod.tpl
+++ b/templates/edit-mod.tpl
@@ -43,9 +43,12 @@
 
 		<div class="editbox short">
 			<label><abbr title="Only mods from the category 'Game Mod' are available in the in-game mod browser">Category</abbr></label>
-			<select name="category" noSearch="noSearch">
+			<select name="category" class="required" noSearch="noSearch" data-placeholder=" ">
+				{if $mod['category'] === null}
+					<option value=""></option>
+				{/if}
 				{foreach from=$modCategories item=name key=category}
-					<option value="{$category}"{if $mod['category'] == $category} selected="selected"{/if}>{$name}</option>
+					<option value="{$category}"{if $mod['category'] !== null && $mod['category'] == $category} selected="selected"{/if}>{$name}</option>
 				{/foreach}
 			</select>
 		</div>

--- a/web/js/edit-asset.js
+++ b/web/js/edit-asset.js
@@ -144,6 +144,7 @@ function submitForm(returntolist) {
 
 		if (!$(this).val()) {
 			$(this).addClass("bg-error");
+			$(this).next(".chosen-container").find(".chosen-single,.chosen-choices").css("background", "#f6d2ca");
 			good = false;
 		}
 	});


### PR DESCRIPTION
Category dropdown no longer defaults to "Game Mod" when creating a new mod. Forces modders to actively pick one.

Requested by Maltiez on Discord ([message](https://discord.com/channels/302152934249070593/810541931469078568/1509130769870880850)):
> Would be nice if this drop down will have no value by default, and required a modder to actively select an option, so ppl pay more attention to it, instead of just ignoring it and putting their server tweaks into game mods category

Changes:
- Default category for new mods: `CATEGORY_GAME_MOD` → `null`
- Template: empty placeholder option (hidden by Chosen, not re-selectable)
- Validation: client-side (`class="required"`) + server-side (`$_POST["category"] === ""` check)
- Chosen widget: propagate error background to visible container on failed validation

Existing mods unaffected - edit page still shows their current category.

<img width="1028" height="486" alt="img1" src="https://github.com/user-attachments/assets/08f384e1-52e2-4ed7-b7d9-a9e592619f41" /> 
<img width="1028" height="486" alt="img2" src="https://github.com/user-attachments/assets/b74f1506-e2f7-449d-8310-9fef46f71a62" />
<img width="1253" height="660" alt="img3" src="https://github.com/user-attachments/assets/51b1689c-168a-4ebf-8300-8d593ecf5cc5" />
