### PR TITLE
perf: skip GROUP BY in mod search when no filter joins

### DIFF
--- a/lib/search-mods.php
+++ b/lib/search-mods.php
@@ -378,8 +378,13 @@ function queryModSearch($searchParams)
 
 	$currentUserId = $user['userId'] ?? 0;
 
+	// :ConditionalDedup — base joins (users, status, files, followedMods) all hit PK/UNIQUE and cannot produce
+	// duplicates. Only filter joins (tags IN, gameversions IN, type via releases) can multiply rows.
+	$dedup = $joinClauses ? 'DISTINCT' : '';
+	$groupBy = $joinClauses ? 'GROUP BY m.modId' : '';
+
 	return $con->getAll("
-		SELECT DISTINCT
+		SELECT $dedup
 			$matchScoreSelect
 			a.createdByUserId,
 			a.name,
@@ -399,7 +404,7 @@ function queryModSearch($searchParams)
 		LEFT JOIN files l ON l.fileId = m.cardLogoFileId
 		$joinClauses
 		$whereClauses
-		GROUP BY m.modId
+		$groupBy
 		ORDER BY $orderBy
 		$limitClause
 	", $sqlParams);

--- a/lib/search-mods.php
+++ b/lib/search-mods.php
@@ -378,8 +378,7 @@ function queryModSearch($searchParams)
 
 	$currentUserId = $user['userId'] ?? 0;
 
-	// :ConditionalDedup — base joins (users, status, files, followedMods) all hit PK/UNIQUE and cannot produce
-	// duplicates. Only filter joins (tags IN, gameversions IN, type via releases) can multiply rows.
+	// Only filter joins (tags, gameversions, type) can multiply rows; base joins all hit PK/UNIQUE.
 	$dedup = $joinClauses ? 'DISTINCT' : '';
 	$groupBy = $joinClauses ? 'GROUP BY m.modId' : '';
 


### PR DESCRIPTION
## Problem

`queryModSearch` always applies `GROUP BY m.modId` + `SELECT DISTINCT`, even when no multiplicative joins are present. The base joins (users, status, files, followedMods) all target PK/UNIQUE and can never produce duplicate rows.

On browse without tag/gameversion/type filters (the most common request - landing page of `/list/mod`), this forces a full 14K-row filesort + temp table for no reason.

## Fix

Condition both `DISTINCT` and `GROUP BY` on whether `$joinClauses` is non-empty. If any filter adds a JOIN, dedup is applied automatically - no manual flag needed, future-proof.

```php
$dedup = $joinClauses ? 'DISTINCT' : '';
$groupBy = $joinClauses ? 'GROUP BY m.modId' : '';
```

## Why this is safe

The base LEFT JOINs all hit unique targets:
- `users` - PK `userId`
- `status` - PK `statusId`
- `userFollowedMods` - UNIQUE `(modId, userId)`
- `files` - PK `fileId`

LEFT JOIN on PK/UNIQUE produces at most 1 row per left row.
Verified empirically: 12259 mods, zero duplicates without GROUP BY.

## Benchmark (14K mods, MariaDB 11.8)

```
                         BEFORE        AFTER       speedup
Browse by trending:       70 ms        0.5 ms       140x
Browse by downloads:      18 ms        0.3 ms        60x
Cursor pagination:        14 ms        0.3 ms        47x
With majorversion:        15 ms         13 ms         ~1x
With tags (GROUP BY on):  0.4 ms       0.4 ms         1x
```

## A/B correctness

MD5 of full ordered result sets - identical in all scenarios:

```
trending L24:      d90634755cdd2beaaf20fa46ec9d69c9
downloads L24:     a4832d1262aa1be920be41b170b807d1
lastReleased L24:  a1ce4fe439f05e760586cc8f6997b2cc
cursor page 2:     7c470179a01f572fbc4af52d23181f89
ALL 12259 mods:    d888acd8c7aaa78c4695986c1e7bfd48
side=client:       b8e06d3cc3366b7e138fe3cef8d22b55
```