### PR TITLE
fix: notification flags toggle and version label typo

### DIFF
--- a/templates/accountsettings.tpl
+++ b/templates/accountsettings.tpl
@@ -83,18 +83,18 @@
 		if(fms) fms.addEventListener('change', e => {
 			const trEl = e.target.parentElement.parentElement.parentElement;
 			const targetModId = trEl.dataset.modid;
-			const oldFlags = parseInt(trEl.dataset.settings);
+			const oldFlags = parseInt(trEl.dataset.flags);
 			const targetBitMask = 1 << parseInt(e.target.dataset.bit);
 			const targetBitState = e.target.checked;
 
 			const newFlags = targetBitState ? (oldFlags | targetBitMask) : (oldFlags & ~targetBitMask);
-			trEl.dataset.settings = newFlags;
+			trEl.dataset.flags = newFlags;
 
 			const xhr = $.post('/api/v2/notifications/settings/followed-mods/'+targetModId, { 'new': newFlags })
 				.fail(jqXHR => {
 					e.target.checked = !targetBitState; // reset setting on error
-					const oldFlags = parseInt(trEl.dataset.settings); // can't reuse outer oldSetting, other bits might have changed in the meantime
-					trEl.dataset.settings = !targetBitState ? (oldFlags | targetBitMask) : (oldFlags & ~targetBitMask);
+					const oldFlags = parseInt(trEl.dataset.flags); // can't reuse outer oldSetting, other bits might have changed in the meantime
+					trEl.dataset.flags = !targetBitState ? (oldFlags | targetBitMask) : (oldFlags & ~targetBitMask);
 				});
 			R.attachDefaultFailHandler(xhr, 'Failed to change settings');
 		});

--- a/templates/edit-release.tpl
+++ b/templates/edit-release.tpl
@@ -229,7 +229,7 @@
 						box.checked = R.compileSemanticVersion(box.value) >= file.gameversiondep;
 						if(box.checked) c++;
 					}
-					labelEl.textContent = `${c} Versions${c !== 1 ? 's' : ''} Selected`;
+					labelEl.textContent = `${c} Version${c !== 1 ? 's' : ''} Selected`;
 					R.addMessage(MSG_CLASS_OK, `Automatically selected ${c} compatible game version${c !== 1 ? 's' : ''}.`, false);
 				}
 			}


### PR DESCRIPTION
accountsettings.tpl: the change handler reads `trEl.dataset.settings` but the attribute is `data-flags`. This makes `parseInt(undefined)` return NaN, so every toggle sends `flags=0` to the server regardless of input.

edit-release.tpl: the auto-select label uses `Versions` as base then appends another `s`, producing "Versionss" for count > 1.