### PR TITLE
scope ban redemption to target user

### DIFF
--- a/moderate-user.php
+++ b/moderate-user.php
@@ -59,7 +59,7 @@ else if(isset($_POST['submit']) && $_POST['submit'] == 'redeem') {
 		$con->startTrans();
 
 		$con->execute('UPDATE users SET bannedUntil = NOW() WHERE userId = ?', [$targetUser['userId']]);
-		$con->execute('UPDATE moderationRecords SET until = NOW() WHERE kind = '.MODACTION_KIND_BAN.' AND until > NOW()');
+		$con->execute('UPDATE moderationRecords SET until = NOW() WHERE kind = '.MODACTION_KIND_BAN.' AND until > NOW() AND targetUserId = ?', [$targetUser['userId']]);
 		logModeratorAction($targetUser['userId'], $user['userId'], MODACTION_KIND_REDEEM, $targetUser['userId'], SQL_DATE_FOREVER, $reason);
 
 		$con->completeTrans();


### PR DESCRIPTION
The UPDATE in the redeem block was missing `AND targetUserId = ?`, so redeeming one user would set `until = NOW()` on every active ban record in the table, corrupting ban metadata for other simultaneously banned users.