### PR TITLE
add composite indexes on notifications

### DIFF
--- a/db/000_tables.sql
+++ b/db/000_tables.sql
@@ -313,7 +313,8 @@ CREATE TABLE IF NOT EXISTS `notifications` (
   `recordId`       INT      NOT NULL,
   `created`        DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`notificationId`),
-  INDEX `userid` (`userId`),
+  INDEX `userid_read_created` (`userId`, `read`, `created`),
+  INDEX `kind_recordid` (`kind`, `recordId`),
   CONSTRAINT `FK_notifications_userId` FOREIGN KEY (`userId`) REFERENCES `users`(`userId`) ON UPDATE CASCADE ON DELETE CASCADE
 )
 ENGINE = InnoDB;

--- a/db/136_migrate.sql
+++ b/db/136_migrate.sql
@@ -1,0 +1,36 @@
+USE `moddb`;
+
+DELIMITER $$
+
+CREATE OR REPLACE PROCEDURE upgrade_database__notification_indexes()
+BEGIN
+
+IF NOT EXISTS( (SELECT * FROM information_schema.STATISTICS WHERE TABLE_SCHEMA='moddb' AND
+ TABLE_NAME='notifications' AND INDEX_NAME='userid_read_created') ) THEN
+
+  CREATE INDEX userid_read_created ON notifications(userId, `read`, created);
+
+END IF;
+
+IF NOT EXISTS( (SELECT * FROM information_schema.STATISTICS WHERE TABLE_SCHEMA='moddb' AND
+ TABLE_NAME='notifications' AND INDEX_NAME='kind_recordid') ) THEN
+
+  CREATE INDEX kind_recordid ON notifications(kind, recordId);
+
+END IF;
+
+IF EXISTS( (SELECT * FROM information_schema.STATISTICS WHERE TABLE_SCHEMA='moddb' AND
+ TABLE_NAME='notifications' AND INDEX_NAME='userid') ) THEN
+
+  DROP INDEX userid ON notifications;
+
+END IF;
+
+
+END $$
+
+CALL upgrade_database__notification_indexes() $$
+
+DELIMITER ;
+
+


### PR DESCRIPTION
Adds `(userId, read, created)` and `(kind, recordId)` on notifications, drops the now-redundant single-column `userid` index.

EXPLAIN with 1400 rows:

| query | before | after |
|-------|--------|-------|
| COUNT unread | ref userid, 200 rows, Using where | ref composite, 50 rows, **Using index** |
| SELECT ORDER BY | 200 rows, **Using filesort** | 50 rows, no filesort |
| UPDATE by kind+recordId | index PRIMARY, **1400 rows full scan** | range kind_recordid, **3 rows** |