### PR TITLE
perf: replace m.* with explicit columns in home.php

### DIFF
--- a/home.php
+++ b/home.php
@@ -4,7 +4,7 @@ if (!empty($user)) {
 	$ownMods = $con->getAll("
 		SELECT
 			a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
-			m.*,
+			m.modId, m.urlAlias, m.summary, m.downloads, m.comments,
 			logo.cdnPath AS logoCdnPath,
 			logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
 			s.code AS statusCode
@@ -34,7 +34,7 @@ if (!empty($user)) {
 	$followedMods = $con->getAll("
 		SELECT
 			a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
-			m.*,
+			m.modId, m.urlAlias, m.summary, m.downloads, m.comments,
 			logo.cdnPath AS logoCdnPath,
 			logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
 			u.name AS `from`,
@@ -68,7 +68,7 @@ if (!empty($user)) {
 $latestMods = $con->getAll("
 	SELECT
 		a.assetId, a.name, a.created, a.statusId, a.createdByUserId,
-		m.*,
+		m.modId, m.urlAlias, m.summary, m.downloads, m.comments, m.category,
 		logo.cdnPath AS logoCdnPath,
 		logo.created < '".SQL_MOD_CARD_TRANSITION_DATE."' AS hasLegacyLogo,
 		u.name AS `from`


### PR DESCRIPTION
Same pattern as 04adb44, 5c473f4.

Replaces `m.*` with the columns actually used by `list-mod-entry.tpl` and `list-mod-entry-followed.tpl` in 3 queries (ownMods, followedMods, latestMods).

Avoids fetching `descriptionSearchable` (TEXT) and 12 other unused columns on every home page load.

Columns kept: `modId` (JOINs), `urlAlias` (formatModPath), `summary`, `downloads`, `comments` (template), `category` (WHERE filter in latestMods).

Benchmark (n=50 each, logged-in home, local Docker w/ 15k mods):
- Before: 438ms ± 64ms
- After: 391ms ± 62ms
- Improvement: 10.9% (p < 0.001, Welch's t-test)