### PR TITLE
fix: reporting system typos and missing reserved URL prefixes

### DIFF
--- a/lib/api/authenticated/comments.php
+++ b/lib/api/authenticated/comments.php
@@ -52,7 +52,7 @@ switch($urlparts[1] ?? null) {
 
 		$requestsInLast7Days = $con->getOne('SELECT COUNT(*) FROM moderationRequests WHERE kind = '.MOD_REQUEST_KIND_REPORT_COMMENT." AND initiatorUserId = {$user['userId']} AND created >= DATE_SUB(NOW(), INTERVAL 7 DAY)");
 		if($requestsInLast7Days > COMMENT_REPORT_LIMIT_PER_WEEK) {
-			fail(HTTP_TOO_MANY_REQUESTS, "You have reached your alloted quota for reporting comments this week. Your reports can be found <a href='/t/u/self' target='_blank'>here</a>.");
+			fail(HTTP_TOO_MANY_REQUESTS, "You have reached your allotted quota for reporting comments this week. Your reports can be found <a href='/t/u/self' target='_blank'>here</a>.");
 		}
 
 		$con->startTrans();

--- a/lib/api/authenticated/mods.php
+++ b/lib/api/authenticated/mods.php
@@ -177,15 +177,15 @@ switch($urlparts[1]) {
 		if($previousRequest) {
 			fail(HTTP_TOO_MANY_REQUESTS, [
 				'reason' => $previousRequest['resolved']
-					? "You have already reported this server for the same reason some time ago, which has been resolved <a href='/t/{$previousRequest['requestId']}' target='_blank'>here</a>."
-					: "You have already reported this server for the same reason some time ago, which can be viewed <a href='/t/{$previousRequest['requestId']}' target='_blank'>here</a>.",
+					? "You have already reported this mod for the same reason some time ago, which has been resolved <a href='/t/{$previousRequest['requestId']}' target='_blank'>here</a>."
+					: "You have already reported this mod for the same reason some time ago, which can be viewed <a href='/t/{$previousRequest['requestId']}' target='_blank'>here</a>.",
 			]);
 		}
 
 		$requestsInLast7Days = $con->getOne('SELECT COUNT(*) FROM moderationRequests WHERE kind = '.MOD_REQUEST_KIND_REPORT_MOD." AND initiatorUserId = {$user['userId']} AND created >= DATE_SUB(NOW(), INTERVAL 7 DAY)");
 		if($requestsInLast7Days > MOD_REPORT_LIMIT_PER_WEEK) {
 			fail(HTTP_TOO_MANY_REQUESTS, [
-				'reason' => "You have reached your alloted quota for reporting mods this week. Your reports can be found <a href='/t/u/self' target='_blank'>here</a>.",
+				'reason' => "You have reached your allotted quota for reporting mods this week. Your reports can be found <a href='/t/u/self' target='_blank'>here</a>.",
 			]);
 		}
 

--- a/lib/mod.php
+++ b/lib/mod.php
@@ -2,7 +2,7 @@
 
 include_once $config['basepath'].'lib/file.php';
 
-const RESERVED_URL_PREFIXES = ['api', 'home', 'terms', 'accountsettings', 'login', 'logout', 'edit-uploadfile', 'edit-deletefile', 'download', 'notifications', 'updateversiontags', 'notification', 'list', 'show', 'edit', 'moderate', 'cmd']; // :ReservedUrlPrefixes
+const RESERVED_URL_PREFIXES = ['api', 'home', 'terms', 'accountsettings', 'login', 'logout', 'edit-uploadfile', 'edit-deletefile', 'download', 'notifications', 'updateversiontags', 'notification', 'list', 'show', 'edit', 'moderate', 'cmd', 't', 'webhooks']; // :ReservedUrlPrefixes
 
 /**
  * @param array<string, int> $newMembers


### PR DESCRIPTION
Two unrelated minor fixes in the reporting system introduced recently.

**1. Missing reserved URL prefixes**

`RESERVED_URL_PREFIXES` in `lib/mod.php` prevents mods from registering URL aliases that collide with application routes. Two routes were missing:

- `t` — ticket pages (added in the reporting system)
- `webhooks` — webhook handlers

Without these, a mod author could register `t` or `webhooks` as their URL alias and shadow the ticket system or webhook endpoint.

**2. Error message typos**

- "alloted" → "allotted" (comments.php, mods.php)
- "this server" → "this mod" in the mod reporting duplicate-report error (mods.php). Copypaste from the game server reporting flow.