### PR TITLE
fix: ticket list query uses wrong userId, moderator view broken

### DIFF
--- a/ticket-list.php
+++ b/ticket-list.php
@@ -15,18 +15,23 @@ require($config['basepath'].'lib/moderation.php');
 if($targetUserHash === 'self' || $targetUserHash === $user['hash']) {
 	$shownUser = $user;
 }
-else {
+else if(canModerate(null, $user)) {
 	$shownUser = getUserByHash($targetUserHash);
 	if(!$shownUser)   showErrorPage(HTTP_NOT_FOUND);
+}
+else {
+	// Non-moderators can only view their own tickets.
+	header('Location: /t/u/self', true, HTTP_FOUND);
+	exit();
 }
 
 
 $tickets = $con->getAll(<<<SQL
 	SELECT requestId, kind, category, stateFlags, IF(LENGTH(requestSearchable) > 256, CONCAT(SUBSTR(requestSearchable, 1, 256), '...'), requestSearchable) AS requestSearchable
 	FROM moderationRequests
-	WHERE initiatorUserId = {$user['userId']}
+	WHERE initiatorUserId = {$shownUser['userId']}
 	ORDER BY created DESC
-SQL);
+SQL); // @security: $shownUser['userId'] comes from the database and is int, therefore sql inert.
 
 
 $view->assign('pagetitle', $shownUser['userId'] == $user['userId'] ? "My Moderation Requests - " : "Moderation Requests initiated by {$shownUser['name']} - ");


### PR DESCRIPTION
The ticket list query in `ticket-list.php` filters by `$user["userId"]` (the logged-in user) instead of `$shownUser["userId"]`. A moderator navigating to `/t/u/{hash}` sees the page title "Moderation Requests initiated by {target name}" but the table shows their own tickets.

Separately, non-moderators could reach `/t/u/{any_hash}` without restriction. No data leaked (the wrong variable accidentally prevented that), but the URL resolved a foreign user object for no reason.

Fix: resolve `$shownUser` conditionally on `canModerate`. Moderators get the requested user, non-moderators redirect to `/t/u/self`. Same pattern as the `$queryFilterOwnTickets` conditional in `ticket.php`. Added `@security` annotation on the query interpolation.