### PR TITLE
remove duplicate chosen.min.css from header

### DIFF
--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -17,7 +17,6 @@
 
 	<link nonce="{$cspNonce}" href="/web/css/chosen.min.css" rel="stylesheet" type="text/css">
 	<link nonce="{$cspNonce}" href="/web/css/jquery.fancybox.min.css" rel="stylesheet" type="text/css">
-	<link nonce="{$cspNonce}" href="/web/js/chosen/chosen.min.css" rel="stylesheet" type="text/css">
 	<link nonce="{$cspNonce}" href="/web/css/datepicker.min.css" rel="stylesheet" type="text/css">
 	<link nonce="{$cspNonce}" href="/web/js/tinymce/plugins/spoiler/css/spoiler.css?v=2" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
header.tpl includes chosen CSS from two paths: /web/css/chosen.min.css (v1.8.7) and /web/js/chosen/chosen.min.css (v1.8.5). CSS cascade means the second wins, so the site renders with v1.8.5 styles despite v1.8.7 being present. This removes the older include.