### PR TITLE
Expose donateUrl in the /api/mod/{id} response

### DIFF
--- a/lib/api/v1/functions.php
+++ b/lib/api/v1/functions.php
@@ -116,6 +116,7 @@ function listMod($modid)
 		"trailervideourl" => $row['trailerVideoUrl'],
 		"issuetrackerurl" => $row['issueTrackerUrl'],
 		"wikiurl"         => $row['wikiUrl'],
+		"donateurl"       => $row['donateUrl'],
 		"downloads"       => intval($row['downloads']),
 		"follows"         => intval($row['follows']),
 		"trendingpoints"  => intval($row['trendingPoints']),


### PR DESCRIPTION
The `mods` table already stores a per-mod `donateUrl` (it's what powers the Donate tab on a mod's page), and `listMod()` already pulls it in via `` `mod`.* ``. It just wasn't being included in the API response.

This adds `donateurl` to the `/api/mod/{id}` payload, alongside the other URL fields, so launchers and community tools can surface an author's donation link straight from the API instead of scraping the mod page.

No schema change and no query change, just the one field in the output array. Happy to add it to the mods list endpoint as well if you'd like it there too.
